### PR TITLE
settings.py: log errors to django log file

### DIFF
--- a/webapp/calamari/calamari/settings.py
+++ b/webapp/calamari/calamari/settings.py
@@ -170,21 +170,19 @@ INSTALLED_APPS = (
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        }
-    },
     'handlers': {
         'mail_admins': {
             'level': 'ERROR',
-            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
-        }
+        },
+        'log_file': {
+            'class': 'logging.handlers.WatchedFileHandler',
+            'filename': '/opt/calamari/log/django.log'
+        },
     },
     'loggers': {
         'django.request': {
-            'handlers': ['mail_admins'],
+            'handlers': ['log_file', 'mail_admins'],
             'level': 'ERROR',
             'propagate': True,
         },


### PR DESCRIPTION
Note that the bootstrap script may need to be updated. The change that I need to make in order for things to shake out was

chmod a+w /opt/calamari/log/django.log

That'd probably work if it was the apache:apache user, too.
