### PR TITLE
django: require login for API access

### DIFF
--- a/webapp/calamari/calamari/settings.py
+++ b/webapp/calamari/calamari/settings.py
@@ -198,6 +198,6 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        'rest_framework.permissions.IsAuthenticated'
     ]
 }


### PR DESCRIPTION
All other Django views (non- rest-framework) appear to have the correct permissions.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
