### PR TITLE
fixes #6917, get some real data into /info/

### DIFF
--- a/calamari-web/calamari_web/urls.py
+++ b/calamari-web/calamari_web/urls.py
@@ -15,6 +15,7 @@ urlpatterns = patterns(
     url(r'^api/v1/auth/logout', 'calamari_web.views.logout'),
     url(r'^api/v1/auth2/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/v1/info', 'calamari_web.views.info'),
+    url(r'^api/v1/grains', 'calamari_web.views.grains'),
 
     url(r'^admin/(?P<path>.*)$', 'calamari_web.views.serve_dir_or_index',
         {'document_root': '%s/admin/' % STATIC_ROOT}),


### PR DESCRIPTION
REGISTERED and LICENSE change from being placeholder
data to being honest "N/A" strings.  The rest are
derived from salt grain data.

Salt grain data for the calamari server is also available
in its unadulterated form from a new /grains/ API resource
which (unlike /info/) requires authenticatio

The 'version' attribute into INFO is still unset pending
refs #7082
