### PR TITLE
calamari_rest: User account PATCH/PUT (password change)

### DIFF
--- a/rest-api/calamari_rest/serializers/v1.py
+++ b/rest-api/calamari_rest/serializers/v1.py
@@ -43,7 +43,7 @@ class UserSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = User
-        fields = ('id', 'username', 'password')
+        fields = ('id', 'username', 'password', 'email')
 
     def to_native(self, obj):
         # Before conversion, remove the password field. This prevents the hash

--- a/rest-api/calamari_rest/urls/v1.py
+++ b/rest-api/calamari_rest/urls/v1.py
@@ -4,8 +4,10 @@ import calamari_rest.views.v1
 
 router = routers.DefaultRouter(trailing_slash=False)
 
-# In v1, the /user list URL existed but only told you usernames
-# In v2 it should include displaynames and email addresses too (TODO #7097)
+# In v1, the user/ URL existed but did almost nothing, it only supported GET and told
+# you your current username.
+# In v2, the view gets filled out to return the displayname and email address to, and support
+# PUT/PATCH operations for users to change their passwords
 router.register(r'user', calamari_rest.views.v1.UserViewSet)
 
 # The cluster view exists in both v1 and v2
@@ -17,11 +19,6 @@ router.register(r'cluster', calamari_rest.views.v1.ClusterViewSet, base_name='cl
 urlpatterns = patterns(
     '',
 
-    # In v1, the user/me URL existed but did almost nothing, it only supported GET and told
-    # you your current username.
-    # In v2, the view gets filled out to return the displayname and email address to, and support
-    # PUT/PATCH operations for users to change their passwords (TODO #7097)
-    url(r'^user/me$', calamari_rest.views.v1.UserMe.as_view()),
     # In v1 this required a POST but also allowed GET for some reason
     # In v2 it's post only
     url(r'^auth/login', calamari_rest.views.v1.login),

--- a/rest-api/calamari_rest/urls/v2.py
+++ b/rest-api/calamari_rest/urls/v2.py
@@ -20,7 +20,6 @@ urlpatterns = patterns(
     url(r'^info', calamari_rest.views.v1.Info.as_view()),
 
     # Wrapping django auth
-    url(r'^user/me', calamari_rest.views.v1.UserMe.as_view()),
     url(r'^auth/login', calamari_rest.views.v1.login),
     url(r'^auth/logout', calamari_rest.views.v1.logout),
 

--- a/rest-api/tests/rest_api_unit_test.py
+++ b/rest-api/tests/rest_api_unit_test.py
@@ -1,0 +1,42 @@
+
+from django.contrib.auth.models import User
+from rest_framework.test import APIClient
+from django.test import TestCase
+import mock
+
+import calamari_rest.views.rpc_view
+
+
+class RestApiUnitTest(TestCase):
+    login = True  # Should setUp log in for us?
+    USERNAME = 'admin'
+    PASSWORD = 'admin'
+
+    def setUp(self):
+        # Patch in a mock for RPCs
+        rpc = mock.Mock()
+        self.rpc = rpc
+        old_init = calamari_rest.views.rpc_view.RPCViewSet.__init__
+
+        def init(_self, *args, **kwargs):
+            old_init(_self, *args, **kwargs)
+            _self.client = rpc
+
+        self._old_init = old_init
+        calamari_rest.views.rpc_view.RPCViewSet.__init__ = init
+
+        # Create a user to log in as
+        User.objects.create_superuser(self.USERNAME, 'admin@admin.com', self.PASSWORD)
+
+        # A client for performing requests to the API
+        self.client = APIClient()
+        if self.login:
+            self.client.login(username='admin', password='admin')
+
+    def tearDown(self):
+        calamari_rest.views.rpc_view.RPCViewSet.__init__ = self._old_init
+
+    def assertStatus(self, response, status_code):
+        self.assertEqual(response.status_code, status_code, "Bad status %s, wanted %s (%s)" % (
+            response.status_code, status_code, response.data
+        ))

--- a/rest-api/tests/test_auth.py
+++ b/rest-api/tests/test_auth.py
@@ -1,0 +1,89 @@
+from django.contrib.auth.models import User
+from rest_framework import status
+from tests.rest_api_unit_test import RestApiUnitTest
+
+
+class TestAuthentication(RestApiUnitTest):
+    login = False
+
+    # A URI that should require login
+    SOMETHING_PRIVILEGED = "/api/v2/grains"
+
+    def test_login(self):
+        # I should get a 403 accessing something privileged
+        response = self.client.get(self.SOMETHING_PRIVILEGED)
+        self.assertStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # I should get a 403 trying to read /user/me
+        response = self.client.get("/api/v2/user/me")
+        self.assertStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Now log in with valid credentials
+        response = self.client.post("/api/v2/auth/login", {
+            'username': self.USERNAME,
+            'password': self.PASSWORD
+        }, format="json")
+        self.assertStatus(response, status.HTTP_200_OK)
+
+        # I should be able to access something privileged
+        response = self.client.get(self.SOMETHING_PRIVILEGED)
+        self.assertStatus(response, status.HTTP_200_OK)
+
+        # Now log out
+        response = self.client.post("/api/v2/auth/logout")
+        self.assertStatus(response, status.HTTP_200_OK)
+
+        # I should have lost the ability to access something privileged
+        response = self.client.get(self.SOMETHING_PRIVILEGED)
+        self.assertStatus(response, status.HTTP_403_FORBIDDEN)
+
+
+class TestUserChanges(RestApiUnitTest):
+    login = True
+
+    def test_change_my_password(self):
+        """
+        That users can change their own password
+        """
+        new_password = 'bob'
+        self.assertNotEqual(new_password, self.PASSWORD)
+
+        # Do a read-write for PUT
+        response = self.client.get("/api/v2/user/me")
+        self.assertStatus(response, status.HTTP_200_OK)
+        user = response.data
+        user['password'] = new_password
+        response = self.client.put("/api/v2/user/me", user)
+        self.assertStatus(response, status.HTTP_200_OK)
+
+        # Now log out
+        response = self.client.post("/api/v2/auth/logout")
+        self.assertStatus(response, status.HTTP_200_OK)
+
+        # Try logging in with old password, should fail
+        response = self.client.post("/api/v2/auth/login", {
+            'username': self.USERNAME,
+            'password': self.PASSWORD
+        }, format="json")
+        self.assertStatus(response, status.HTTP_401_UNAUTHORIZED)
+
+        # Try logging in with new password, should succeed
+        response = self.client.post("/api/v2/auth/login", {
+            'username': self.USERNAME,
+            'password': new_password
+        }, format="json")
+        self.assertStatus(response, status.HTTP_200_OK)
+
+    def test_change_anothers_password(self):
+        """
+        That users cannot change one anothers' password.
+        """
+        stranger = User.objects.create_superuser("stranger", "stranger@admin.com", "stranger_pwd")
+        me = User.objects.get(username=self.USERNAME)
+        # I can't change his
+        response = self.client.patch("/api/v2/user/%s" % stranger.id, {'password': 'new'})
+        self.assertStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # But I can change my own
+        response = self.client.patch("/api/v2/user/%s" % me.id, {'password': 'new'})
+        self.assertStatus(response, status.HTTP_200_OK)

--- a/rest-api/tests/test_keys.py
+++ b/rest-api/tests/test_keys.py
@@ -1,36 +1,8 @@
 
-from django.contrib.auth.models import User
 from rest_framework import status
-from rest_framework.test import APIClient
-from django.test import TestCase
 import mock
 
-import calamari_rest.views.rpc_view
-
-
-class RestApiUnitTest(TestCase):
-    def setUp(self):
-        # Patch in a mock for RPCs
-        rpc = mock.Mock()
-        self.rpc = rpc
-        old_init = calamari_rest.views.rpc_view.RPCViewSet.__init__
-
-        def init(_self, *args, **kwargs):
-            old_init(_self, *args, **kwargs)
-            _self.client = rpc
-
-        self._old_init = old_init
-        calamari_rest.views.rpc_view.RPCViewSet.__init__ = init
-
-        # Create a user to log in as
-        User.objects.create_superuser('admin', 'admin@admin.com', 'admin')
-
-        # A client for performing requests to the API
-        self.client = APIClient()
-        self.client.login(username='admin', password='admin')
-
-    def tearDown(self):
-        calamari_rest.views.rpc_view.RPCViewSet.__init__ = self._old_init
+from tests.rest_api_unit_test import RestApiUnitTest
 
 
 class TestKey(RestApiUnitTest):


### PR DESCRIPTION
Users can change their own password but not those of
other users.  Refactored the user view code to
avoid a separate view for /user/me, so that all
ops can refer to a PK or 'me'.

Fixes: #7097
