### PR TITLE
salt: Fix reactor declaration

### DIFF
--- a/salt/srv/reactor/start.sls
+++ b/salt/srv/reactor/start.sls
@@ -1,5 +1,7 @@
 highstate_run:
   cmd.state.highstate:
     - tgt: {{ data['id'] }}
+
+sync_modules:
   cmd.saltutil.sync_modules:
     - tgt: {{ data['id'] }}


### PR DESCRIPTION
Turns out it just wasn't legal to specify two commands in one
'chunk', but two chunks is fine.  The diamond install part
gets called now.

Fixes: #7380
