### PR TITLE
calamari_rest: work around restrictive grains permissions

### DIFF
--- a/rest-api/calamari_rest/views/v2.py
+++ b/rest-api/calamari_rest/views/v2.py
@@ -532,8 +532,13 @@ server then the FQDN will be modified to its correct value.
                                                          use_cached_grains=True,
                                                          grains_fallback=False,
                                                          opts=salt_config)
+
         try:
-            return Response(pillar_util.get_minion_grains()[fqdn])
+            # We (ab)use an internal interface to get at the cache by minion ID
+            # instead of by glob, because the process of resolving the glob
+            # relies on access to the root only PKI folder.
+            cache_grains, cache_pillar = pillar_util._get_cached_minion_data(fqdn)
+            return Response(cache_grains[fqdn])
         except KeyError:
             return Response(status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
The cache of minion data doesn't actually require
root privileges, but the method that salt uses to
resolve a minion glob to minion IDs does.  Circumvent
this by using the private _get_cached_minion_data
function to get straight at what we want.

Fixes: #7783
