### PR TITLE
cthulhu: Fix failure parsing OSD map for pool mapping

### DIFF
--- a/cthulhu/tests/osd_map-7883.json
+++ b/cthulhu/tests/osd_map-7883.json
@@ -1,0 +1,8264 @@
+{
+    "pool_max": 8, 
+    "max_osd": 168, 
+    "created": "2014-03-05 13:06:50.181089", 
+    "crush": {
+        "rules": [
+            {
+                "min_size": 1, 
+                "rule_name": "data", 
+                "steps": [
+                    {
+                        "item": -1, 
+                        "op": "take"
+                    }, 
+                    {
+                        "num": 0, 
+                        "type": "osd", 
+                        "op": "choose_firstn"
+                    }, 
+                    {
+                        "op": "emit"
+                    }
+                ], 
+                "ruleset": 0, 
+                "type": 1, 
+                "rule_id": 0, 
+                "max_size": 10
+            }, 
+            {
+                "min_size": 1, 
+                "rule_name": "metadata", 
+                "steps": [
+                    {
+                        "item": -1, 
+                        "op": "take"
+                    }, 
+                    {
+                        "num": 0, 
+                        "type": "osd", 
+                        "op": "choose_firstn"
+                    }, 
+                    {
+                        "op": "emit"
+                    }
+                ], 
+                "ruleset": 1, 
+                "type": 1, 
+                "rule_id": 1, 
+                "max_size": 10
+            }, 
+            {
+                "min_size": 1, 
+                "rule_name": "rbd", 
+                "steps": [
+                    {
+                        "item": -1, 
+                        "op": "take"
+                    }, 
+                    {
+                        "num": 0, 
+                        "type": "osd", 
+                        "op": "choose_firstn"
+                    }, 
+                    {
+                        "op": "emit"
+                    }
+                ], 
+                "ruleset": 2, 
+                "type": 1, 
+                "rule_id": 2, 
+                "max_size": 10
+            }
+        ], 
+        "tunables": {
+            "choose_local_fallback_tries": 0, 
+            "chooseleaf_descend_once": 1, 
+            "choose_total_tries": 50, 
+            "choose_local_tries": 0
+        }, 
+        "buckets": [
+            {
+                "hash": "rjenkins1", 
+                "name": "default", 
+                "weight": 2422181, 
+                "type_id": 6, 
+                "alg": "straw", 
+                "type_name": "root", 
+                "items": [
+                    {
+                        "id": -2, 
+                        "weight": 403701, 
+                        "pos": 0
+                    }, 
+                    {
+                        "id": -3, 
+                        "weight": 403701, 
+                        "pos": 1
+                    }, 
+                    {
+                        "id": -4, 
+                        "weight": 403701, 
+                        "pos": 2
+                    }, 
+                    {
+                        "id": -5, 
+                        "weight": 403701, 
+                        "pos": 3
+                    }, 
+                    {
+                        "id": -6, 
+                        "weight": 403701, 
+                        "pos": 4
+                    }, 
+                    {
+                        "id": -7, 
+                        "weight": 403676, 
+                        "pos": 5
+                    }
+                ], 
+                "id": -1
+            }, 
+            {
+                "hash": "rjenkins1", 
+                "name": "mira102", 
+                "weight": 403676, 
+                "type_id": 1, 
+                "alg": "straw", 
+                "type_name": "host", 
+                "items": [
+                    {
+                        "id": 0, 
+                        "weight": 14417, 
+                        "pos": 0
+                    }, 
+                    {
+                        "id": 1, 
+                        "weight": 14417, 
+                        "pos": 1
+                    }, 
+                    {
+                        "id": 2, 
+                        "weight": 14417, 
+                        "pos": 2
+                    }, 
+                    {
+                        "id": 3, 
+                        "weight": 14417, 
+                        "pos": 3
+                    }, 
+                    {
+                        "id": 4, 
+                        "weight": 14417, 
+                        "pos": 4
+                    }, 
+                    {
+                        "id": 5, 
+                        "weight": 14417, 
+                        "pos": 5
+                    }, 
+                    {
+                        "id": 6, 
+                        "weight": 14417, 
+                        "pos": 6
+                    }, 
+                    {
+                        "id": 7, 
+                        "weight": 14417, 
+                        "pos": 7
+                    }, 
+                    {
+                        "id": 8, 
+                        "weight": 14417, 
+                        "pos": 8
+                    }, 
+                    {
+                        "id": 9, 
+                        "weight": 14417, 
+                        "pos": 9
+                    }, 
+                    {
+                        "id": 10, 
+                        "weight": 14417, 
+                        "pos": 10
+                    }, 
+                    {
+                        "id": 11, 
+                        "weight": 14417, 
+                        "pos": 11
+                    }, 
+                    {
+                        "id": 12, 
+                        "weight": 14417, 
+                        "pos": 12
+                    }, 
+                    {
+                        "id": 13, 
+                        "weight": 14417, 
+                        "pos": 13
+                    }, 
+                    {
+                        "id": 14, 
+                        "weight": 14417, 
+                        "pos": 14
+                    }, 
+                    {
+                        "id": 15, 
+                        "weight": 14417, 
+                        "pos": 15
+                    }, 
+                    {
+                        "id": 16, 
+                        "weight": 14417, 
+                        "pos": 16
+                    }, 
+                    {
+                        "id": 17, 
+                        "weight": 14417, 
+                        "pos": 17
+                    }, 
+                    {
+                        "id": 18, 
+                        "weight": 14417, 
+                        "pos": 18
+                    }, 
+                    {
+                        "id": 19, 
+                        "weight": 14417, 
+                        "pos": 19
+                    }, 
+                    {
+                        "id": 20, 
+                        "weight": 14417, 
+                        "pos": 20
+                    }, 
+                    {
+                        "id": 21, 
+                        "weight": 14417, 
+                        "pos": 21
+                    }, 
+                    {
+                        "id": 22, 
+                        "weight": 14417, 
+                        "pos": 22
+                    }, 
+                    {
+                        "id": 23, 
+                        "weight": 14417, 
+                        "pos": 23
+                    }, 
+                    {
+                        "id": 24, 
+                        "weight": 14417, 
+                        "pos": 24
+                    }, 
+                    {
+                        "id": 25, 
+                        "weight": 14417, 
+                        "pos": 25
+                    }, 
+                    {
+                        "id": 26, 
+                        "weight": 14417, 
+                        "pos": 26
+                    }, 
+                    {
+                        "id": 27, 
+                        "weight": 14417, 
+                        "pos": 27
+                    }
+                ], 
+                "id": -2
+            }, 
+            {
+                "hash": "rjenkins1", 
+                "name": "mira103", 
+                "weight": 403676, 
+                "type_id": 1, 
+                "alg": "straw", 
+                "type_name": "host", 
+                "items": [
+                    {
+                        "id": 28, 
+                        "weight": 14417, 
+                        "pos": 0
+                    }, 
+                    {
+                        "id": 29, 
+                        "weight": 14417, 
+                        "pos": 1
+                    }, 
+                    {
+                        "id": 30, 
+                        "weight": 14417, 
+                        "pos": 2
+                    }, 
+                    {
+                        "id": 31, 
+                        "weight": 14417, 
+                        "pos": 3
+                    }, 
+                    {
+                        "id": 32, 
+                        "weight": 14417, 
+                        "pos": 4
+                    }, 
+                    {
+                        "id": 33, 
+                        "weight": 14417, 
+                        "pos": 5
+                    }, 
+                    {
+                        "id": 34, 
+                        "weight": 14417, 
+                        "pos": 6
+                    }, 
+                    {
+                        "id": 35, 
+                        "weight": 14417, 
+                        "pos": 7
+                    }, 
+                    {
+                        "id": 36, 
+                        "weight": 14417, 
+                        "pos": 8
+                    }, 
+                    {
+                        "id": 37, 
+                        "weight": 14417, 
+                        "pos": 9
+                    }, 
+                    {
+                        "id": 38, 
+                        "weight": 14417, 
+                        "pos": 10
+                    }, 
+                    {
+                        "id": 39, 
+                        "weight": 14417, 
+                        "pos": 11
+                    }, 
+                    {
+                        "id": 40, 
+                        "weight": 14417, 
+                        "pos": 12
+                    }, 
+                    {
+                        "id": 41, 
+                        "weight": 14417, 
+                        "pos": 13
+                    }, 
+                    {
+                        "id": 42, 
+                        "weight": 14417, 
+                        "pos": 14
+                    }, 
+                    {
+                        "id": 43, 
+                        "weight": 14417, 
+                        "pos": 15
+                    }, 
+                    {
+                        "id": 44, 
+                        "weight": 14417, 
+                        "pos": 16
+                    }, 
+                    {
+                        "id": 45, 
+                        "weight": 14417, 
+                        "pos": 17
+                    }, 
+                    {
+                        "id": 46, 
+                        "weight": 14417, 
+                        "pos": 18
+                    }, 
+                    {
+                        "id": 47, 
+                        "weight": 14417, 
+                        "pos": 19
+                    }, 
+                    {
+                        "id": 48, 
+                        "weight": 14417, 
+                        "pos": 20
+                    }, 
+                    {
+                        "id": 49, 
+                        "weight": 14417, 
+                        "pos": 21
+                    }, 
+                    {
+                        "id": 50, 
+                        "weight": 14417, 
+                        "pos": 22
+                    }, 
+                    {
+                        "id": 51, 
+                        "weight": 14417, 
+                        "pos": 23
+                    }, 
+                    {
+                        "id": 52, 
+                        "weight": 14417, 
+                        "pos": 24
+                    }, 
+                    {
+                        "id": 53, 
+                        "weight": 14417, 
+                        "pos": 25
+                    }, 
+                    {
+                        "id": 54, 
+                        "weight": 14417, 
+                        "pos": 26
+                    }, 
+                    {
+                        "id": 55, 
+                        "weight": 14417, 
+                        "pos": 27
+                    }
+                ], 
+                "id": -3
+            }, 
+            {
+                "hash": "rjenkins1", 
+                "name": "mira110", 
+                "weight": 403676, 
+                "type_id": 1, 
+                "alg": "straw", 
+                "type_name": "host", 
+                "items": [
+                    {
+                        "id": 56, 
+                        "weight": 14417, 
+                        "pos": 0
+                    }, 
+                    {
+                        "id": 57, 
+                        "weight": 14417, 
+                        "pos": 1
+                    }, 
+                    {
+                        "id": 58, 
+                        "weight": 14417, 
+                        "pos": 2
+                    }, 
+                    {
+                        "id": 59, 
+                        "weight": 14417, 
+                        "pos": 3
+                    }, 
+                    {
+                        "id": 60, 
+                        "weight": 14417, 
+                        "pos": 4
+                    }, 
+                    {
+                        "id": 61, 
+                        "weight": 14417, 
+                        "pos": 5
+                    }, 
+                    {
+                        "id": 62, 
+                        "weight": 14417, 
+                        "pos": 6
+                    }, 
+                    {
+                        "id": 63, 
+                        "weight": 14417, 
+                        "pos": 7
+                    }, 
+                    {
+                        "id": 64, 
+                        "weight": 14417, 
+                        "pos": 8
+                    }, 
+                    {
+                        "id": 65, 
+                        "weight": 14417, 
+                        "pos": 9
+                    }, 
+                    {
+                        "id": 66, 
+                        "weight": 14417, 
+                        "pos": 10
+                    }, 
+                    {
+                        "id": 67, 
+                        "weight": 14417, 
+                        "pos": 11
+                    }, 
+                    {
+                        "id": 68, 
+                        "weight": 14417, 
+                        "pos": 12
+                    }, 
+                    {
+                        "id": 69, 
+                        "weight": 14417, 
+                        "pos": 13
+                    }, 
+                    {
+                        "id": 70, 
+                        "weight": 14417, 
+                        "pos": 14
+                    }, 
+                    {
+                        "id": 71, 
+                        "weight": 14417, 
+                        "pos": 15
+                    }, 
+                    {
+                        "id": 72, 
+                        "weight": 14417, 
+                        "pos": 16
+                    }, 
+                    {
+                        "id": 73, 
+                        "weight": 14417, 
+                        "pos": 17
+                    }, 
+                    {
+                        "id": 74, 
+                        "weight": 14417, 
+                        "pos": 18
+                    }, 
+                    {
+                        "id": 75, 
+                        "weight": 14417, 
+                        "pos": 19
+                    }, 
+                    {
+                        "id": 76, 
+                        "weight": 14417, 
+                        "pos": 20
+                    }, 
+                    {
+                        "id": 77, 
+                        "weight": 14417, 
+                        "pos": 21
+                    }, 
+                    {
+                        "id": 78, 
+                        "weight": 14417, 
+                        "pos": 22
+                    }, 
+                    {
+                        "id": 79, 
+                        "weight": 14417, 
+                        "pos": 23
+                    }, 
+                    {
+                        "id": 80, 
+                        "weight": 14417, 
+                        "pos": 24
+                    }, 
+                    {
+                        "id": 81, 
+                        "weight": 14417, 
+                        "pos": 25
+                    }, 
+                    {
+                        "id": 82, 
+                        "weight": 14417, 
+                        "pos": 26
+                    }, 
+                    {
+                        "id": 83, 
+                        "weight": 14417, 
+                        "pos": 27
+                    }
+                ], 
+                "id": -4
+            }, 
+            {
+                "hash": "rjenkins1", 
+                "name": "mira118", 
+                "weight": 403676, 
+                "type_id": 1, 
+                "alg": "straw", 
+                "type_name": "host", 
+                "items": [
+                    {
+                        "id": 84, 
+                        "weight": 14417, 
+                        "pos": 0
+                    }, 
+                    {
+                        "id": 85, 
+                        "weight": 14417, 
+                        "pos": 1
+                    }, 
+                    {
+                        "id": 86, 
+                        "weight": 14417, 
+                        "pos": 2
+                    }, 
+                    {
+                        "id": 87, 
+                        "weight": 14417, 
+                        "pos": 3
+                    }, 
+                    {
+                        "id": 88, 
+                        "weight": 14417, 
+                        "pos": 4
+                    }, 
+                    {
+                        "id": 89, 
+                        "weight": 14417, 
+                        "pos": 5
+                    }, 
+                    {
+                        "id": 90, 
+                        "weight": 14417, 
+                        "pos": 6
+                    }, 
+                    {
+                        "id": 91, 
+                        "weight": 14417, 
+                        "pos": 7
+                    }, 
+                    {
+                        "id": 92, 
+                        "weight": 14417, 
+                        "pos": 8
+                    }, 
+                    {
+                        "id": 93, 
+                        "weight": 14417, 
+                        "pos": 9
+                    }, 
+                    {
+                        "id": 94, 
+                        "weight": 14417, 
+                        "pos": 10
+                    }, 
+                    {
+                        "id": 95, 
+                        "weight": 14417, 
+                        "pos": 11
+                    }, 
+                    {
+                        "id": 96, 
+                        "weight": 14417, 
+                        "pos": 12
+                    }, 
+                    {
+                        "id": 97, 
+                        "weight": 14417, 
+                        "pos": 13
+                    }, 
+                    {
+                        "id": 98, 
+                        "weight": 14417, 
+                        "pos": 14
+                    }, 
+                    {
+                        "id": 99, 
+                        "weight": 14417, 
+                        "pos": 15
+                    }, 
+                    {
+                        "id": 100, 
+                        "weight": 14417, 
+                        "pos": 16
+                    }, 
+                    {
+                        "id": 101, 
+                        "weight": 14417, 
+                        "pos": 17
+                    }, 
+                    {
+                        "id": 102, 
+                        "weight": 14417, 
+                        "pos": 18
+                    }, 
+                    {
+                        "id": 103, 
+                        "weight": 14417, 
+                        "pos": 19
+                    }, 
+                    {
+                        "id": 104, 
+                        "weight": 14417, 
+                        "pos": 20
+                    }, 
+                    {
+                        "id": 105, 
+                        "weight": 14417, 
+                        "pos": 21
+                    }, 
+                    {
+                        "id": 106, 
+                        "weight": 14417, 
+                        "pos": 22
+                    }, 
+                    {
+                        "id": 107, 
+                        "weight": 14417, 
+                        "pos": 23
+                    }, 
+                    {
+                        "id": 108, 
+                        "weight": 14417, 
+                        "pos": 24
+                    }, 
+                    {
+                        "id": 109, 
+                        "weight": 14417, 
+                        "pos": 25
+                    }, 
+                    {
+                        "id": 110, 
+                        "weight": 14417, 
+                        "pos": 26
+                    }, 
+                    {
+                        "id": 111, 
+                        "weight": 14417, 
+                        "pos": 27
+                    }
+                ], 
+                "id": -5
+            }, 
+            {
+                "hash": "rjenkins1", 
+                "name": "mira122", 
+                "weight": 403676, 
+                "type_id": 1, 
+                "alg": "straw", 
+                "type_name": "host", 
+                "items": [
+                    {
+                        "id": 112, 
+                        "weight": 14417, 
+                        "pos": 0
+                    }, 
+                    {
+                        "id": 113, 
+                        "weight": 14417, 
+                        "pos": 1
+                    }, 
+                    {
+                        "id": 114, 
+                        "weight": 14417, 
+                        "pos": 2
+                    }, 
+                    {
+                        "id": 115, 
+                        "weight": 14417, 
+                        "pos": 3
+                    }, 
+                    {
+                        "id": 116, 
+                        "weight": 14417, 
+                        "pos": 4
+                    }, 
+                    {
+                        "id": 117, 
+                        "weight": 14417, 
+                        "pos": 5
+                    }, 
+                    {
+                        "id": 118, 
+                        "weight": 14417, 
+                        "pos": 6
+                    }, 
+                    {
+                        "id": 119, 
+                        "weight": 14417, 
+                        "pos": 7
+                    }, 
+                    {
+                        "id": 120, 
+                        "weight": 14417, 
+                        "pos": 8
+                    }, 
+                    {
+                        "id": 121, 
+                        "weight": 14417, 
+                        "pos": 9
+                    }, 
+                    {
+                        "id": 122, 
+                        "weight": 14417, 
+                        "pos": 10
+                    }, 
+                    {
+                        "id": 123, 
+                        "weight": 14417, 
+                        "pos": 11
+                    }, 
+                    {
+                        "id": 124, 
+                        "weight": 14417, 
+                        "pos": 12
+                    }, 
+                    {
+                        "id": 125, 
+                        "weight": 14417, 
+                        "pos": 13
+                    }, 
+                    {
+                        "id": 126, 
+                        "weight": 14417, 
+                        "pos": 14
+                    }, 
+                    {
+                        "id": 127, 
+                        "weight": 14417, 
+                        "pos": 15
+                    }, 
+                    {
+                        "id": 128, 
+                        "weight": 14417, 
+                        "pos": 16
+                    }, 
+                    {
+                        "id": 129, 
+                        "weight": 14417, 
+                        "pos": 17
+                    }, 
+                    {
+                        "id": 130, 
+                        "weight": 14417, 
+                        "pos": 18
+                    }, 
+                    {
+                        "id": 131, 
+                        "weight": 14417, 
+                        "pos": 19
+                    }, 
+                    {
+                        "id": 132, 
+                        "weight": 14417, 
+                        "pos": 20
+                    }, 
+                    {
+                        "id": 133, 
+                        "weight": 14417, 
+                        "pos": 21
+                    }, 
+                    {
+                        "id": 134, 
+                        "weight": 14417, 
+                        "pos": 22
+                    }, 
+                    {
+                        "id": 135, 
+                        "weight": 14417, 
+                        "pos": 23
+                    }, 
+                    {
+                        "id": 136, 
+                        "weight": 14417, 
+                        "pos": 24
+                    }, 
+                    {
+                        "id": 137, 
+                        "weight": 14417, 
+                        "pos": 25
+                    }, 
+                    {
+                        "id": 138, 
+                        "weight": 14417, 
+                        "pos": 26
+                    }, 
+                    {
+                        "id": 139, 
+                        "weight": 14417, 
+                        "pos": 27
+                    }
+                ], 
+                "id": -6
+            }, 
+            {
+                "hash": "rjenkins1", 
+                "name": "mira048", 
+                "weight": 403676, 
+                "type_id": 1, 
+                "alg": "straw", 
+                "type_name": "host", 
+                "items": [
+                    {
+                        "id": 140, 
+                        "weight": 14417, 
+                        "pos": 0
+                    }, 
+                    {
+                        "id": 141, 
+                        "weight": 14417, 
+                        "pos": 1
+                    }, 
+                    {
+                        "id": 142, 
+                        "weight": 14417, 
+                        "pos": 2
+                    }, 
+                    {
+                        "id": 143, 
+                        "weight": 14417, 
+                        "pos": 3
+                    }, 
+                    {
+                        "id": 144, 
+                        "weight": 14417, 
+                        "pos": 4
+                    }, 
+                    {
+                        "id": 145, 
+                        "weight": 14417, 
+                        "pos": 5
+                    }, 
+                    {
+                        "id": 146, 
+                        "weight": 14417, 
+                        "pos": 6
+                    }, 
+                    {
+                        "id": 147, 
+                        "weight": 14417, 
+                        "pos": 7
+                    }, 
+                    {
+                        "id": 148, 
+                        "weight": 14417, 
+                        "pos": 8
+                    }, 
+                    {
+                        "id": 149, 
+                        "weight": 14417, 
+                        "pos": 9
+                    }, 
+                    {
+                        "id": 150, 
+                        "weight": 14417, 
+                        "pos": 10
+                    }, 
+                    {
+                        "id": 151, 
+                        "weight": 14417, 
+                        "pos": 11
+                    }, 
+                    {
+                        "id": 152, 
+                        "weight": 14417, 
+                        "pos": 12
+                    }, 
+                    {
+                        "id": 153, 
+                        "weight": 14417, 
+                        "pos": 13
+                    }, 
+                    {
+                        "id": 154, 
+                        "weight": 14417, 
+                        "pos": 14
+                    }, 
+                    {
+                        "id": 155, 
+                        "weight": 14417, 
+                        "pos": 15
+                    }, 
+                    {
+                        "id": 156, 
+                        "weight": 14417, 
+                        "pos": 16
+                    }, 
+                    {
+                        "id": 157, 
+                        "weight": 14417, 
+                        "pos": 17
+                    }, 
+                    {
+                        "id": 158, 
+                        "weight": 14417, 
+                        "pos": 18
+                    }, 
+                    {
+                        "id": 159, 
+                        "weight": 14417, 
+                        "pos": 19
+                    }, 
+                    {
+                        "id": 160, 
+                        "weight": 14417, 
+                        "pos": 20
+                    }, 
+                    {
+                        "id": 161, 
+                        "weight": 14417, 
+                        "pos": 21
+                    }, 
+                    {
+                        "id": 162, 
+                        "weight": 14417, 
+                        "pos": 22
+                    }, 
+                    {
+                        "id": 163, 
+                        "weight": 14417, 
+                        "pos": 23
+                    }, 
+                    {
+                        "id": 164, 
+                        "weight": 14417, 
+                        "pos": 24
+                    }, 
+                    {
+                        "id": 165, 
+                        "weight": 14417, 
+                        "pos": 25
+                    }, 
+                    {
+                        "id": 166, 
+                        "weight": 14417, 
+                        "pos": 26
+                    }, 
+                    {
+                        "id": 167, 
+                        "weight": 14417, 
+                        "pos": 27
+                    }
+                ], 
+                "id": -7
+            }
+        ], 
+        "types": [
+            {
+                "name": "osd", 
+                "type_id": 0
+            }, 
+            {
+                "name": "host", 
+                "type_id": 1
+            }, 
+            {
+                "name": "rack", 
+                "type_id": 2
+            }, 
+            {
+                "name": "row", 
+                "type_id": 3
+            }, 
+            {
+                "name": "room", 
+                "type_id": 4
+            }, 
+            {
+                "name": "datacenter", 
+                "type_id": 5
+            }, 
+            {
+                "name": "root", 
+                "type_id": 6
+            }
+        ], 
+        "devices": [
+            {
+                "id": 0, 
+                "name": "osd.0"
+            }, 
+            {
+                "id": 1, 
+                "name": "osd.1"
+            }, 
+            {
+                "id": 2, 
+                "name": "osd.2"
+            }, 
+            {
+                "id": 3, 
+                "name": "osd.3"
+            }, 
+            {
+                "id": 4, 
+                "name": "osd.4"
+            }, 
+            {
+                "id": 5, 
+                "name": "osd.5"
+            }, 
+            {
+                "id": 6, 
+                "name": "osd.6"
+            }, 
+            {
+                "id": 7, 
+                "name": "osd.7"
+            }, 
+            {
+                "id": 8, 
+                "name": "osd.8"
+            }, 
+            {
+                "id": 9, 
+                "name": "osd.9"
+            }, 
+            {
+                "id": 10, 
+                "name": "osd.10"
+            }, 
+            {
+                "id": 11, 
+                "name": "osd.11"
+            }, 
+            {
+                "id": 12, 
+                "name": "osd.12"
+            }, 
+            {
+                "id": 13, 
+                "name": "osd.13"
+            }, 
+            {
+                "id": 14, 
+                "name": "osd.14"
+            }, 
+            {
+                "id": 15, 
+                "name": "osd.15"
+            }, 
+            {
+                "id": 16, 
+                "name": "osd.16"
+            }, 
+            {
+                "id": 17, 
+                "name": "osd.17"
+            }, 
+            {
+                "id": 18, 
+                "name": "osd.18"
+            }, 
+            {
+                "id": 19, 
+                "name": "osd.19"
+            }, 
+            {
+                "id": 20, 
+                "name": "osd.20"
+            }, 
+            {
+                "id": 21, 
+                "name": "osd.21"
+            }, 
+            {
+                "id": 22, 
+                "name": "osd.22"
+            }, 
+            {
+                "id": 23, 
+                "name": "osd.23"
+            }, 
+            {
+                "id": 24, 
+                "name": "osd.24"
+            }, 
+            {
+                "id": 25, 
+                "name": "osd.25"
+            }, 
+            {
+                "id": 26, 
+                "name": "osd.26"
+            }, 
+            {
+                "id": 27, 
+                "name": "osd.27"
+            }, 
+            {
+                "id": 28, 
+                "name": "osd.28"
+            }, 
+            {
+                "id": 29, 
+                "name": "osd.29"
+            }, 
+            {
+                "id": 30, 
+                "name": "osd.30"
+            }, 
+            {
+                "id": 31, 
+                "name": "osd.31"
+            }, 
+            {
+                "id": 32, 
+                "name": "osd.32"
+            }, 
+            {
+                "id": 33, 
+                "name": "osd.33"
+            }, 
+            {
+                "id": 34, 
+                "name": "osd.34"
+            }, 
+            {
+                "id": 35, 
+                "name": "osd.35"
+            }, 
+            {
+                "id": 36, 
+                "name": "osd.36"
+            }, 
+            {
+                "id": 37, 
+                "name": "osd.37"
+            }, 
+            {
+                "id": 38, 
+                "name": "osd.38"
+            }, 
+            {
+                "id": 39, 
+                "name": "osd.39"
+            }, 
+            {
+                "id": 40, 
+                "name": "osd.40"
+            }, 
+            {
+                "id": 41, 
+                "name": "osd.41"
+            }, 
+            {
+                "id": 42, 
+                "name": "osd.42"
+            }, 
+            {
+                "id": 43, 
+                "name": "osd.43"
+            }, 
+            {
+                "id": 44, 
+                "name": "osd.44"
+            }, 
+            {
+                "id": 45, 
+                "name": "osd.45"
+            }, 
+            {
+                "id": 46, 
+                "name": "osd.46"
+            }, 
+            {
+                "id": 47, 
+                "name": "osd.47"
+            }, 
+            {
+                "id": 48, 
+                "name": "osd.48"
+            }, 
+            {
+                "id": 49, 
+                "name": "osd.49"
+            }, 
+            {
+                "id": 50, 
+                "name": "osd.50"
+            }, 
+            {
+                "id": 51, 
+                "name": "osd.51"
+            }, 
+            {
+                "id": 52, 
+                "name": "osd.52"
+            }, 
+            {
+                "id": 53, 
+                "name": "osd.53"
+            }, 
+            {
+                "id": 54, 
+                "name": "osd.54"
+            }, 
+            {
+                "id": 55, 
+                "name": "osd.55"
+            }, 
+            {
+                "id": 56, 
+                "name": "osd.56"
+            }, 
+            {
+                "id": 57, 
+                "name": "osd.57"
+            }, 
+            {
+                "id": 58, 
+                "name": "osd.58"
+            }, 
+            {
+                "id": 59, 
+                "name": "osd.59"
+            }, 
+            {
+                "id": 60, 
+                "name": "osd.60"
+            }, 
+            {
+                "id": 61, 
+                "name": "osd.61"
+            }, 
+            {
+                "id": 62, 
+                "name": "osd.62"
+            }, 
+            {
+                "id": 63, 
+                "name": "osd.63"
+            }, 
+            {
+                "id": 64, 
+                "name": "osd.64"
+            }, 
+            {
+                "id": 65, 
+                "name": "osd.65"
+            }, 
+            {
+                "id": 66, 
+                "name": "osd.66"
+            }, 
+            {
+                "id": 67, 
+                "name": "osd.67"
+            }, 
+            {
+                "id": 68, 
+                "name": "osd.68"
+            }, 
+            {
+                "id": 69, 
+                "name": "osd.69"
+            }, 
+            {
+                "id": 70, 
+                "name": "osd.70"
+            }, 
+            {
+                "id": 71, 
+                "name": "osd.71"
+            }, 
+            {
+                "id": 72, 
+                "name": "osd.72"
+            }, 
+            {
+                "id": 73, 
+                "name": "osd.73"
+            }, 
+            {
+                "id": 74, 
+                "name": "osd.74"
+            }, 
+            {
+                "id": 75, 
+                "name": "osd.75"
+            }, 
+            {
+                "id": 76, 
+                "name": "osd.76"
+            }, 
+            {
+                "id": 77, 
+                "name": "osd.77"
+            }, 
+            {
+                "id": 78, 
+                "name": "osd.78"
+            }, 
+            {
+                "id": 79, 
+                "name": "osd.79"
+            }, 
+            {
+                "id": 80, 
+                "name": "osd.80"
+            }, 
+            {
+                "id": 81, 
+                "name": "osd.81"
+            }, 
+            {
+                "id": 82, 
+                "name": "osd.82"
+            }, 
+            {
+                "id": 83, 
+                "name": "osd.83"
+            }, 
+            {
+                "id": 84, 
+                "name": "osd.84"
+            }, 
+            {
+                "id": 85, 
+                "name": "osd.85"
+            }, 
+            {
+                "id": 86, 
+                "name": "osd.86"
+            }, 
+            {
+                "id": 87, 
+                "name": "osd.87"
+            }, 
+            {
+                "id": 88, 
+                "name": "osd.88"
+            }, 
+            {
+                "id": 89, 
+                "name": "osd.89"
+            }, 
+            {
+                "id": 90, 
+                "name": "osd.90"
+            }, 
+            {
+                "id": 91, 
+                "name": "osd.91"
+            }, 
+            {
+                "id": 92, 
+                "name": "osd.92"
+            }, 
+            {
+                "id": 93, 
+                "name": "osd.93"
+            }, 
+            {
+                "id": 94, 
+                "name": "osd.94"
+            }, 
+            {
+                "id": 95, 
+                "name": "osd.95"
+            }, 
+            {
+                "id": 96, 
+                "name": "osd.96"
+            }, 
+            {
+                "id": 97, 
+                "name": "osd.97"
+            }, 
+            {
+                "id": 98, 
+                "name": "osd.98"
+            }, 
+            {
+                "id": 99, 
+                "name": "osd.99"
+            }, 
+            {
+                "id": 100, 
+                "name": "osd.100"
+            }, 
+            {
+                "id": 101, 
+                "name": "osd.101"
+            }, 
+            {
+                "id": 102, 
+                "name": "osd.102"
+            }, 
+            {
+                "id": 103, 
+                "name": "osd.103"
+            }, 
+            {
+                "id": 104, 
+                "name": "osd.104"
+            }, 
+            {
+                "id": 105, 
+                "name": "osd.105"
+            }, 
+            {
+                "id": 106, 
+                "name": "osd.106"
+            }, 
+            {
+                "id": 107, 
+                "name": "osd.107"
+            }, 
+            {
+                "id": 108, 
+                "name": "osd.108"
+            }, 
+            {
+                "id": 109, 
+                "name": "osd.109"
+            }, 
+            {
+                "id": 110, 
+                "name": "osd.110"
+            }, 
+            {
+                "id": 111, 
+                "name": "osd.111"
+            }, 
+            {
+                "id": 112, 
+                "name": "osd.112"
+            }, 
+            {
+                "id": 113, 
+                "name": "osd.113"
+            }, 
+            {
+                "id": 114, 
+                "name": "osd.114"
+            }, 
+            {
+                "id": 115, 
+                "name": "osd.115"
+            }, 
+            {
+                "id": 116, 
+                "name": "osd.116"
+            }, 
+            {
+                "id": 117, 
+                "name": "osd.117"
+            }, 
+            {
+                "id": 118, 
+                "name": "osd.118"
+            }, 
+            {
+                "id": 119, 
+                "name": "osd.119"
+            }, 
+            {
+                "id": 120, 
+                "name": "osd.120"
+            }, 
+            {
+                "id": 121, 
+                "name": "osd.121"
+            }, 
+            {
+                "id": 122, 
+                "name": "osd.122"
+            }, 
+            {
+                "id": 123, 
+                "name": "osd.123"
+            }, 
+            {
+                "id": 124, 
+                "name": "osd.124"
+            }, 
+            {
+                "id": 125, 
+                "name": "osd.125"
+            }, 
+            {
+                "id": 126, 
+                "name": "osd.126"
+            }, 
+            {
+                "id": 127, 
+                "name": "osd.127"
+            }, 
+            {
+                "id": 128, 
+                "name": "osd.128"
+            }, 
+            {
+                "id": 129, 
+                "name": "osd.129"
+            }, 
+            {
+                "id": 130, 
+                "name": "osd.130"
+            }, 
+            {
+                "id": 131, 
+                "name": "osd.131"
+            }, 
+            {
+                "id": 132, 
+                "name": "osd.132"
+            }, 
+            {
+                "id": 133, 
+                "name": "osd.133"
+            }, 
+            {
+                "id": 134, 
+                "name": "osd.134"
+            }, 
+            {
+                "id": 135, 
+                "name": "osd.135"
+            }, 
+            {
+                "id": 136, 
+                "name": "osd.136"
+            }, 
+            {
+                "id": 137, 
+                "name": "osd.137"
+            }, 
+            {
+                "id": 138, 
+                "name": "osd.138"
+            }, 
+            {
+                "id": 139, 
+                "name": "osd.139"
+            }, 
+            {
+                "id": 140, 
+                "name": "osd.140"
+            }, 
+            {
+                "id": 141, 
+                "name": "osd.141"
+            }, 
+            {
+                "id": 142, 
+                "name": "osd.142"
+            }, 
+            {
+                "id": 143, 
+                "name": "osd.143"
+            }, 
+            {
+                "id": 144, 
+                "name": "osd.144"
+            }, 
+            {
+                "id": 145, 
+                "name": "osd.145"
+            }, 
+            {
+                "id": 146, 
+                "name": "osd.146"
+            }, 
+            {
+                "id": 147, 
+                "name": "osd.147"
+            }, 
+            {
+                "id": 148, 
+                "name": "osd.148"
+            }, 
+            {
+                "id": 149, 
+                "name": "osd.149"
+            }, 
+            {
+                "id": 150, 
+                "name": "osd.150"
+            }, 
+            {
+                "id": 151, 
+                "name": "osd.151"
+            }, 
+            {
+                "id": 152, 
+                "name": "osd.152"
+            }, 
+            {
+                "id": 153, 
+                "name": "osd.153"
+            }, 
+            {
+                "id": 154, 
+                "name": "osd.154"
+            }, 
+            {
+                "id": 155, 
+                "name": "osd.155"
+            }, 
+            {
+                "id": 156, 
+                "name": "osd.156"
+            }, 
+            {
+                "id": 157, 
+                "name": "osd.157"
+            }, 
+            {
+                "id": 158, 
+                "name": "osd.158"
+            }, 
+            {
+                "id": 159, 
+                "name": "osd.159"
+            }, 
+            {
+                "id": 160, 
+                "name": "osd.160"
+            }, 
+            {
+                "id": 161, 
+                "name": "osd.161"
+            }, 
+            {
+                "id": 162, 
+                "name": "osd.162"
+            }, 
+            {
+                "id": 163, 
+                "name": "osd.163"
+            }, 
+            {
+                "id": 164, 
+                "name": "osd.164"
+            }, 
+            {
+                "id": 165, 
+                "name": "osd.165"
+            }, 
+            {
+                "id": 166, 
+                "name": "osd.166"
+            }, 
+            {
+                "id": 167, 
+                "name": "osd.167"
+            }
+        ]
+    }, 
+    "tree": {
+        "nodes": [
+            {
+                "type_id": 6, 
+                "type": "root", 
+                "children": [
+                    -7, 
+                    -6, 
+                    -5, 
+                    -4, 
+                    -3, 
+                    -2
+                ], 
+                "name": "default", 
+                "id": -1
+            }, 
+            {
+                "type_id": 1, 
+                "type": "host", 
+                "children": [
+                    27, 
+                    26, 
+                    25, 
+                    24, 
+                    23, 
+                    22, 
+                    21, 
+                    20, 
+                    19, 
+                    18, 
+                    17, 
+                    16, 
+                    15, 
+                    14, 
+                    13, 
+                    12, 
+                    11, 
+                    10, 
+                    9, 
+                    8, 
+                    7, 
+                    6, 
+                    5, 
+                    4, 
+                    3, 
+                    2, 
+                    1, 
+                    0
+                ], 
+                "name": "mira102", 
+                "id": -2
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.0", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 0
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.1", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 1
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.2", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 2
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.3", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 3
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.4", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 4
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.5", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 5
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.6", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 6
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.7", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 7
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.8", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 8
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.9", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 9
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.10", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 10
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.11", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 11
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.12", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 12
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.13", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 13
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.14", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 14
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.15", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 15
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.16", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 16
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.17", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 17
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.18", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 18
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.19", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 19
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.20", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 20
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.21", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 21
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.22", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 22
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.23", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 23
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.24", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 24
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.25", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 25
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.26", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 26
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.27", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 27
+            }, 
+            {
+                "type_id": 1, 
+                "type": "host", 
+                "children": [
+                    55, 
+                    54, 
+                    53, 
+                    52, 
+                    51, 
+                    50, 
+                    49, 
+                    48, 
+                    47, 
+                    46, 
+                    45, 
+                    44, 
+                    43, 
+                    42, 
+                    41, 
+                    40, 
+                    39, 
+                    38, 
+                    37, 
+                    36, 
+                    35, 
+                    34, 
+                    33, 
+                    32, 
+                    31, 
+                    30, 
+                    29, 
+                    28
+                ], 
+                "name": "mira103", 
+                "id": -3
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.28", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 28
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.29", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 29
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.30", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 30
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.31", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 31
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.32", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 32
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.33", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 33
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.34", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 34
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.35", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 35
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.36", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 36
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.37", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 37
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.38", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 38
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.39", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 39
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.40", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 40
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.41", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 41
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.42", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 42
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.43", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 43
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.44", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 44
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.45", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 45
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.46", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 46
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.47", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 47
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.48", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 48
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.49", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 49
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.50", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 50
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.51", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 51
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.52", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 52
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.53", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 53
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.54", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 54
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.55", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 55
+            }, 
+            {
+                "type_id": 1, 
+                "type": "host", 
+                "children": [
+                    83, 
+                    82, 
+                    81, 
+                    80, 
+                    79, 
+                    78, 
+                    77, 
+                    76, 
+                    75, 
+                    74, 
+                    73, 
+                    72, 
+                    71, 
+                    70, 
+                    69, 
+                    68, 
+                    67, 
+                    66, 
+                    65, 
+                    64, 
+                    63, 
+                    62, 
+                    61, 
+                    60, 
+                    59, 
+                    58, 
+                    57, 
+                    56
+                ], 
+                "name": "mira110", 
+                "id": -4
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.56", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 56
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.57", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 57
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.58", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 58
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.59", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 59
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.60", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 60
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.61", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 61
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.62", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 62
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.63", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 63
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.64", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 64
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.65", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 65
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.66", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 66
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.67", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 67
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.68", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 68
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.69", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 69
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.70", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 70
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.71", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 71
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.72", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 72
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.73", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 73
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.74", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 74
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.75", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 75
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.76", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 76
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.77", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 77
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.78", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 78
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.79", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 79
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.80", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 80
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.81", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 81
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.82", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 82
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.83", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 83
+            }, 
+            {
+                "type_id": 1, 
+                "type": "host", 
+                "children": [
+                    111, 
+                    110, 
+                    109, 
+                    108, 
+                    107, 
+                    106, 
+                    105, 
+                    104, 
+                    103, 
+                    102, 
+                    101, 
+                    100, 
+                    99, 
+                    98, 
+                    97, 
+                    96, 
+                    95, 
+                    94, 
+                    93, 
+                    92, 
+                    91, 
+                    90, 
+                    89, 
+                    88, 
+                    87, 
+                    86, 
+                    85, 
+                    84
+                ], 
+                "name": "mira118", 
+                "id": -5
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.84", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 84
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.85", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 85
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.86", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 86
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.87", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 87
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.88", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 88
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.89", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 89
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.90", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 90
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.91", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 91
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.92", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 92
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.93", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 93
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.94", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 94
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.95", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 95
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.96", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 96
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.97", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 97
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.98", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 98
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.99", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 99
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.100", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 100
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.101", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 101
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.102", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 102
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.103", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 103
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.104", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 104
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.105", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 105
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.106", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 106
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.107", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 107
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.108", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 108
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.109", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 109
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.110", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 110
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.111", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 111
+            }, 
+            {
+                "type_id": 1, 
+                "type": "host", 
+                "children": [
+                    139, 
+                    138, 
+                    137, 
+                    136, 
+                    135, 
+                    134, 
+                    133, 
+                    132, 
+                    131, 
+                    130, 
+                    129, 
+                    128, 
+                    127, 
+                    126, 
+                    125, 
+                    124, 
+                    123, 
+                    122, 
+                    121, 
+                    120, 
+                    119, 
+                    118, 
+                    117, 
+                    116, 
+                    115, 
+                    114, 
+                    113, 
+                    112
+                ], 
+                "name": "mira122", 
+                "id": -6
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.112", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 112
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.113", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 113
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.114", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 114
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.115", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 115
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.116", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 116
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.117", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 117
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.118", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 118
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.119", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 119
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.120", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 120
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.121", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 121
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.122", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 122
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.123", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 123
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.124", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 124
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.125", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 125
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.126", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 126
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.127", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 127
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.128", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 128
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.129", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 129
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.130", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 130
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.131", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 131
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.132", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 132
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.133", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 133
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.134", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 134
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.135", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 135
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.136", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 136
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.137", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 137
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.138", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 138
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.139", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 139
+            }, 
+            {
+                "type_id": 1, 
+                "type": "host", 
+                "children": [
+                    167, 
+                    166, 
+                    165, 
+                    164, 
+                    163, 
+                    162, 
+                    161, 
+                    160, 
+                    159, 
+                    158, 
+                    157, 
+                    156, 
+                    155, 
+                    154, 
+                    153, 
+                    152, 
+                    151, 
+                    150, 
+                    149, 
+                    148, 
+                    147, 
+                    146, 
+                    145, 
+                    144, 
+                    143, 
+                    142, 
+                    141, 
+                    140
+                ], 
+                "name": "mira048", 
+                "id": -7
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.140", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 140
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.141", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 141
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.142", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 142
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.143", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 143
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.144", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 144
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.145", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 145
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.146", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 146
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.147", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 147
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.148", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 148
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.149", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 149
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.150", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 150
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.151", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 151
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.152", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 152
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.153", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 153
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.154", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 154
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.155", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 155
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.156", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 156
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.157", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 157
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.158", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 158
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.159", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 159
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.160", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 160
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.161", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 161
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.162", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 162
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.163", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 163
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.164", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 164
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.165", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 165
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.166", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 166
+            }, 
+            {
+                "status": "up", 
+                "name": "osd.167", 
+                "exists": 1, 
+                "type_id": 0, 
+                "reweight": "1.000000", 
+                "crush_weight": "0.219986", 
+                "depth": 2, 
+                "type": "osd", 
+                "id": 167
+            }
+        ], 
+        "stray": []
+    }, 
+    "modified": "2014-03-26 22:49:12.006795", 
+    "osd_xinfo": [
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 0, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 1, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 2, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 3, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 4, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 5, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 6, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 7, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 8, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 9, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 10, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 11, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 12, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 13, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 14, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 15, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 16, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 17, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 18, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 19, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 20, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 21, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 22, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 23, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 24, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 25, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 26, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 27, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 28, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 29, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 30, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 31, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 32, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 33, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 34, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 35, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 36, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 37, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 38, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 39, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 40, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 41, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 42, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 43, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 44, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 45, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 46, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 47, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 48, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 49, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 50, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 51, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 52, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 53, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 54, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 55, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 56, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 57, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 58, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 59, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 60, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 61, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 62, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 63, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 64, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 65, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 66, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 67, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 68, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 69, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 70, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 71, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 72, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 73, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 74, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 75, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 76, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 77, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 78, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 79, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 80, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 81, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 82, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 83, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 84, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 85, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 86, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 87, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 88, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 89, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 90, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 91, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 92, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 93, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 94, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 95, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 96, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 97, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 98, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 99, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 100, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 101, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 102, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 103, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 104, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 105, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 106, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 107, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 108, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 109, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 110, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 111, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 112, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 113, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 114, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 115, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 116, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 117, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 118, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 119, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 120, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 121, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 122, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 123, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 124, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 125, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 126, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 127, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 128, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 129, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 130, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 131, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 132, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 133, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 134, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 135, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 136, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 137, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 138, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 139, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.300000", 
+            "down_stamp": "2014-03-21 16:09:25.352576", 
+            "osd": 140, 
+            "laggy_interval": 1
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 141, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 142, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 143, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 144, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 145, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 146, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 147, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 148, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 149, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 150, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 151, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 152, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 153, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 154, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 155, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 156, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 157, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 158, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 159, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 160, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 161, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 162, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "2014-03-17 22:40:16.697397", 
+            "osd": 163, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 164, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 165, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 166, 
+            "laggy_interval": 0
+        }, 
+        {
+            "laggy_probability": "0.000000", 
+            "down_stamp": "0.000000", 
+            "osd": 167, 
+            "laggy_interval": 0
+        }
+    ], 
+    "osds": [
+        {
+            "heartbeat_back_addr": "10.214.136.116:6802/4533", 
+            "uuid": "8e22468a-7e0e-4e3c-8bd7-25c03f667f7d", 
+            "heartbeat_front_addr": "10.214.136.116:6803/4533", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 905, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6800/4533", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.136.116:6801/4533", 
+            "osd": 0
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6806/5956", 
+            "uuid": "857dec6a-b85d-4e2f-a923-2e026e03704e", 
+            "heartbeat_front_addr": "10.214.136.116:6807/5956", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 908, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6804/5956", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.136.116:6805/5956", 
+            "osd": 1
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6810/8344", 
+            "uuid": "a512ae76-2e73-421d-acc7-5e2c2bb5f1ef", 
+            "heartbeat_front_addr": "10.214.136.116:6811/8344", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 911, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6808/8344", 
+            "up_thru": 1571, 
+            "cluster_addr": "10.214.136.116:6809/8344", 
+            "osd": 2
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6814/8674", 
+            "uuid": "4fbb6c2c-1a1d-49a5-91cf-f85816180728", 
+            "heartbeat_front_addr": "10.214.136.116:6815/8674", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 912, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6812/8674", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.116:6813/8674", 
+            "osd": 3
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6818/10435", 
+            "uuid": "c63fd20e-3632-4a4d-aeb5-bd136bb5280d", 
+            "heartbeat_front_addr": "10.214.136.116:6819/10435", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 915, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6816/10435", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.136.116:6817/10435", 
+            "osd": 4
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6822/12014", 
+            "uuid": "1235befe-932c-44c0-8147-b8278b963b72", 
+            "heartbeat_front_addr": "10.214.136.116:6823/12014", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 918, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6820/12014", 
+            "up_thru": 1584, 
+            "cluster_addr": "10.214.136.116:6821/12014", 
+            "osd": 5
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6826/13577", 
+            "uuid": "8e419dad-448a-447f-9861-2e7f832e229d", 
+            "heartbeat_front_addr": "10.214.136.116:6827/13577", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 921, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6824/13577", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.116:6825/13577", 
+            "osd": 6
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6830/15988", 
+            "uuid": "5c43fae8-e6d0-4093-a980-a7b27173fd4e", 
+            "heartbeat_front_addr": "10.214.136.116:6831/15988", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 924, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6828/15988", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.136.116:6829/15988", 
+            "osd": 7
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6834/16432", 
+            "uuid": "0ed2f07a-6a48-4dd5-b87a-cd4f6b5f8dca", 
+            "heartbeat_front_addr": "10.214.136.116:6835/16432", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 925, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6832/16432", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.116:6833/16432", 
+            "osd": 8
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6838/18301", 
+            "uuid": "9af363f3-f894-4f6b-8c17-6e10b22ee6ce", 
+            "heartbeat_front_addr": "10.214.136.116:6839/18301", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 928, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6836/18301", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.136.116:6837/18301", 
+            "osd": 9
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6842/19842", 
+            "uuid": "c135d8bd-88da-4e68-815a-168e5b117a08", 
+            "heartbeat_front_addr": "10.214.136.116:6843/19842", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 931, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6840/19842", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.136.116:6841/19842", 
+            "osd": 10
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6846/22818", 
+            "uuid": "25702f21-fbd7-4b0f-9e2a-60ad3f51f423", 
+            "heartbeat_front_addr": "10.214.136.116:6847/22818", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 934, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6844/22818", 
+            "up_thru": 1580, 
+            "cluster_addr": "10.214.136.116:6845/22818", 
+            "osd": 11
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6850/24416", 
+            "uuid": "237ab1ff-528a-4837-b036-f27d7adb726b", 
+            "heartbeat_front_addr": "10.214.136.116:6851/24416", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 937, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6848/24416", 
+            "up_thru": 1581, 
+            "cluster_addr": "10.214.136.116:6849/24416", 
+            "osd": 12
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6854/24707", 
+            "uuid": "2a8b7e4e-50cf-4b27-9004-5767a60cb855", 
+            "heartbeat_front_addr": "10.214.136.116:6855/24707", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 938, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6852/24707", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.136.116:6853/24707", 
+            "osd": 13
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6858/26061", 
+            "uuid": "762fe01f-c035-4f50-b3b7-f33bea2c5152", 
+            "heartbeat_front_addr": "10.214.136.116:6859/26061", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 941, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6856/26061", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.116:6857/26061", 
+            "osd": 14
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6862/27987", 
+            "uuid": "f474fcd8-3bff-4a41-8601-42ff9d97e1c7", 
+            "heartbeat_front_addr": "10.214.136.116:6863/27987", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 944, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6860/27987", 
+            "up_thru": 1591, 
+            "cluster_addr": "10.214.136.116:6861/27987", 
+            "osd": 15
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6866/29482", 
+            "uuid": "1f78ce2a-e7c3-4899-a03f-6ddc05227f8d", 
+            "heartbeat_front_addr": "10.214.136.116:6867/29482", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 947, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6864/29482", 
+            "up_thru": 1571, 
+            "cluster_addr": "10.214.136.116:6865/29482", 
+            "osd": 16
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6870/31161", 
+            "uuid": "ef642735-cca7-468e-a9fe-898a94242341", 
+            "heartbeat_front_addr": "10.214.136.116:6871/31161", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 950, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6868/31161", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.136.116:6869/31161", 
+            "osd": 17
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6874/386", 
+            "uuid": "256b5d28-8ad5-487c-b7fe-5f2e351d3d2a", 
+            "heartbeat_front_addr": "10.214.136.116:6875/386", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 953, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6872/386", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.136.116:6873/386", 
+            "osd": 18
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6878/3243", 
+            "uuid": "fb4a1773-5794-4fc9-b67a-555f3a98d75f", 
+            "heartbeat_front_addr": "10.214.136.116:6879/3243", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 956, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6876/3243", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.136.116:6877/3243", 
+            "osd": 19
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6882/3714", 
+            "uuid": "327a95f2-8268-4df6-85f8-d4ae0c93eb9d", 
+            "heartbeat_front_addr": "10.214.136.116:6883/3714", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 957, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6880/3714", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.136.116:6881/3714", 
+            "osd": 20
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6886/5459", 
+            "uuid": "e5b6f306-6de5-4aba-834f-7200e4282615", 
+            "heartbeat_front_addr": "10.214.136.116:6887/5459", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 960, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6884/5459", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.136.116:6885/5459", 
+            "osd": 21
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6890/8277", 
+            "uuid": "c3a980b6-db7b-44ff-84a9-f033e1154059", 
+            "heartbeat_front_addr": "10.214.136.116:6891/8277", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 963, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6888/8277", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.136.116:6889/8277", 
+            "osd": 22
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6894/8851", 
+            "uuid": "5d9a9e5f-09ca-446c-9798-a251587dfb38", 
+            "heartbeat_front_addr": "10.214.136.116:6895/8851", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 966, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6892/8851", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.136.116:6893/8851", 
+            "osd": 23
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6898/10609", 
+            "uuid": "7ea6b38b-c674-4cbd-84b2-ab174b75c153", 
+            "heartbeat_front_addr": "10.214.136.116:6899/10609", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 969, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6896/10609", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.116:6897/10609", 
+            "osd": 24
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6902/13491", 
+            "uuid": "4d554637-bbd9-4b76-be71-f185d969f404", 
+            "heartbeat_front_addr": "10.214.136.116:6903/13491", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 972, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6900/13491", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.136.116:6901/13491", 
+            "osd": 25
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6906/14077", 
+            "uuid": "b90e415a-42cf-4cf3-a8c5-d9d28a8d9c7c", 
+            "heartbeat_front_addr": "10.214.136.116:6907/14077", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 974, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6904/14077", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.136.116:6905/14077", 
+            "osd": 26
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.116:6910/15734", 
+            "uuid": "1f126546-d95b-463b-81da-95e61cd25304", 
+            "heartbeat_front_addr": "10.214.136.116:6911/15734", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 977, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.116:6908/15734", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.136.116:6909/15734", 
+            "osd": 27
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6802/1050", 
+            "uuid": "ea4c5206-e2d8-4325-9167-6f65f8a37f22", 
+            "heartbeat_front_addr": "10.214.136.114:6803/1050", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 980, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6800/1050", 
+            "up_thru": 1578, 
+            "cluster_addr": "10.214.136.114:6801/1050", 
+            "osd": 28
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6806/1324", 
+            "uuid": "59a0bb21-6fe9-430a-a1f0-e3abe4d3f262", 
+            "heartbeat_front_addr": "10.214.136.114:6807/1324", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 982, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6804/1324", 
+            "up_thru": 1571, 
+            "cluster_addr": "10.214.136.114:6805/1324", 
+            "osd": 29
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6810/1697", 
+            "uuid": "adc20a6f-0dcb-4795-bedf-85a586e0c584", 
+            "heartbeat_front_addr": "10.214.136.114:6811/1697", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 984, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6808/1697", 
+            "up_thru": 1352, 
+            "cluster_addr": "10.214.136.114:6809/1697", 
+            "osd": 30
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6814/2041", 
+            "uuid": "db0b4599-24bc-43a2-bbd1-5fb21f2b8b8a", 
+            "heartbeat_front_addr": "10.214.136.114:6815/2041", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 986, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6812/2041", 
+            "up_thru": 1597, 
+            "cluster_addr": "10.214.136.114:6813/2041", 
+            "osd": 31
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6818/2497", 
+            "uuid": "7e4368e1-c53f-4ce7-ab43-b370ceaeeb42", 
+            "heartbeat_front_addr": "10.214.136.114:6819/2497", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 988, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6816/2497", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.114:6817/2497", 
+            "osd": 32
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6822/2748", 
+            "uuid": "f2535f8b-ca33-4d77-b33b-9f2b32989dd3", 
+            "heartbeat_front_addr": "10.214.136.114:6823/2748", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 989, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6820/2748", 
+            "up_thru": 1578, 
+            "cluster_addr": "10.214.136.114:6821/2748", 
+            "osd": 33
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6826/3085", 
+            "uuid": "7c32ac73-03b3-4dcf-b913-f8d66047bd8e", 
+            "heartbeat_front_addr": "10.214.136.114:6827/3085", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 991, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6824/3085", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.136.114:6825/3085", 
+            "osd": 34
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6830/3441", 
+            "uuid": "856d9497-09da-4bbc-be6a-04a1d936d242", 
+            "heartbeat_front_addr": "10.214.136.114:6831/3441", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 993, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6828/3441", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.136.114:6829/3441", 
+            "osd": 35
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6834/3861", 
+            "uuid": "5c5e1332-ada7-45dd-b6b1-5d92b3357b08", 
+            "heartbeat_front_addr": "10.214.136.114:6835/3861", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 995, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6832/3861", 
+            "up_thru": 1347, 
+            "cluster_addr": "10.214.136.114:6833/3861", 
+            "osd": 36
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6838/4176", 
+            "uuid": "a8cf74c0-5a9b-415e-a29d-794bf60ce509", 
+            "heartbeat_front_addr": "10.214.136.114:6839/4176", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 997, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6836/4176", 
+            "up_thru": 1591, 
+            "cluster_addr": "10.214.136.114:6837/4176", 
+            "osd": 37
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6842/4456", 
+            "uuid": "be948a5e-381f-4dc9-be3d-64e77736a144", 
+            "heartbeat_front_addr": "10.214.136.114:6843/4456", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 999, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6840/4456", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.136.114:6841/4456", 
+            "osd": 38
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6846/4845", 
+            "uuid": "e18a06bb-789f-4c9e-9641-8eafb44f9616", 
+            "heartbeat_front_addr": "10.214.136.114:6847/4845", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1001, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6844/4845", 
+            "up_thru": 1577, 
+            "cluster_addr": "10.214.136.114:6845/4845", 
+            "osd": 39
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6850/5162", 
+            "uuid": "921b7d63-e088-43d9-a6a2-d56d8402d817", 
+            "heartbeat_front_addr": "10.214.136.114:6851/5162", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1003, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6848/5162", 
+            "up_thru": 1585, 
+            "cluster_addr": "10.214.136.114:6849/5162", 
+            "osd": 40
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6854/5440", 
+            "uuid": "56398e70-d99a-4502-9090-5a930b61a168", 
+            "heartbeat_front_addr": "10.214.136.114:6855/5440", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1005, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6852/5440", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.136.114:6853/5440", 
+            "osd": 41
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6858/5779", 
+            "uuid": "d41369c5-caf8-4a3b-8664-e25c72c3f48e", 
+            "heartbeat_front_addr": "10.214.136.114:6859/5779", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1007, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6856/5779", 
+            "up_thru": 1571, 
+            "cluster_addr": "10.214.136.114:6857/5779", 
+            "osd": 42
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6862/6103", 
+            "uuid": "360c1be4-befb-46ff-b077-8a6ed5e9302b", 
+            "heartbeat_front_addr": "10.214.136.114:6863/6103", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1009, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6860/6103", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.114:6861/6103", 
+            "osd": 43
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6866/6505", 
+            "uuid": "f017f2ec-f2aa-456f-8d13-c9fff7e524ad", 
+            "heartbeat_front_addr": "10.214.136.114:6867/6505", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1012, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6864/6505", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.136.114:6865/6505", 
+            "osd": 44
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6870/6844", 
+            "uuid": "f805a86f-964c-48cc-bd7a-e1ee1f81d91d", 
+            "heartbeat_front_addr": "10.214.136.114:6871/6844", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1014, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6868/6844", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.136.114:6869/6844", 
+            "osd": 45
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6874/7137", 
+            "uuid": "ee258ffc-fab0-49e3-8afe-0c5a7c219746", 
+            "heartbeat_front_addr": "10.214.136.114:6875/7137", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1016, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6872/7137", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.136.114:6873/7137", 
+            "osd": 46
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6878/7449", 
+            "uuid": "c4fbdf6b-1a63-4226-8f21-05a29af097c7", 
+            "heartbeat_front_addr": "10.214.136.114:6879/7449", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1018, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6876/7449", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.136.114:6877/7449", 
+            "osd": 47
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6882/7859", 
+            "uuid": "fcf3dea4-0324-4557-af0c-05f618dc74ad", 
+            "heartbeat_front_addr": "10.214.136.114:6883/7859", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1021, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6880/7859", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.136.114:6881/7859", 
+            "osd": 48
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6886/8177", 
+            "uuid": "642eda60-f600-45af-8e93-21a3776ba4e4", 
+            "heartbeat_front_addr": "10.214.136.114:6887/8177", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1022, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6884/8177", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.136.114:6885/8177", 
+            "osd": 49
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6890/8466", 
+            "uuid": "18a40adf-04fb-4cf7-80e3-34e908507679", 
+            "heartbeat_front_addr": "10.214.136.114:6891/8466", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1024, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6888/8466", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.136.114:6889/8466", 
+            "osd": 50
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6894/8794", 
+            "uuid": "0358d9c0-ffec-4f80-a068-79d287211849", 
+            "heartbeat_front_addr": "10.214.136.114:6895/8794", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1026, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6892/8794", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.136.114:6893/8794", 
+            "osd": 51
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6898/9247", 
+            "uuid": "6ea04aee-b681-44ab-a295-bc06b0a94161", 
+            "heartbeat_front_addr": "10.214.136.114:6899/9247", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1029, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6896/9247", 
+            "up_thru": 1352, 
+            "cluster_addr": "10.214.136.114:6897/9247", 
+            "osd": 52
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6902/9511", 
+            "uuid": "b58edcdc-b8e1-4dda-863b-c2747c47f37e", 
+            "heartbeat_front_addr": "10.214.136.114:6903/9511", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1030, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6900/9511", 
+            "up_thru": 1578, 
+            "cluster_addr": "10.214.136.114:6901/9511", 
+            "osd": 53
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6906/9854", 
+            "uuid": "f82a6516-6eab-40bb-82fe-88283205c7ac", 
+            "heartbeat_front_addr": "10.214.136.114:6907/9854", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1032, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6904/9854", 
+            "up_thru": 1582, 
+            "cluster_addr": "10.214.136.114:6905/9854", 
+            "osd": 54
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.136.114:6910/10130", 
+            "uuid": "0063f893-bac5-4f43-b699-90847a621f59", 
+            "heartbeat_front_addr": "10.214.136.114:6911/10130", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1034, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.136.114:6908/10130", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.136.114:6909/10130", 
+            "osd": 55
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6802/5090", 
+            "uuid": "ada5ed2c-c06b-4a4b-b019-d3f6d14a9a1d", 
+            "heartbeat_front_addr": "10.214.137.138:6803/5090", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1037, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6800/5090", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.137.138:6801/5090", 
+            "osd": 56
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6806/5362", 
+            "uuid": "a67e4f14-deae-477a-9499-5e57d09f1b0b", 
+            "heartbeat_front_addr": "10.214.137.138:6807/5362", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1038, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6804/5362", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.137.138:6805/5362", 
+            "osd": 57
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6810/5658", 
+            "uuid": "56c81151-a653-487d-b2d2-b3d6ac3f5c97", 
+            "heartbeat_front_addr": "10.214.137.138:6811/5658", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1040, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6808/5658", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.137.138:6809/5658", 
+            "osd": 58
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6814/5935", 
+            "uuid": "0f7d72e3-948a-4611-97d8-d3f83bb298e7", 
+            "heartbeat_front_addr": "10.214.137.138:6815/5935", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1041, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6812/5935", 
+            "up_thru": 1597, 
+            "cluster_addr": "10.214.137.138:6813/5935", 
+            "osd": 59
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6818/6450", 
+            "uuid": "2778fa1f-a1d8-4e60-ae09-b82366d07eaf", 
+            "heartbeat_front_addr": "10.214.137.138:6819/6450", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1044, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6816/6450", 
+            "up_thru": 1559, 
+            "cluster_addr": "10.214.137.138:6817/6450", 
+            "osd": 60
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6822/6704", 
+            "uuid": "59d5e02c-6ccf-4c7f-8047-d3aa246970d0", 
+            "heartbeat_front_addr": "10.214.137.138:6823/6704", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1045, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6820/6704", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.138:6821/6704", 
+            "osd": 61
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6826/7057", 
+            "uuid": "526242cf-3582-4336-9e7d-3afad76e899c", 
+            "heartbeat_front_addr": "10.214.137.138:6827/7057", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1047, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6824/7057", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.138:6825/7057", 
+            "osd": 62
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6830/7335", 
+            "uuid": "824e21e2-f46b-4571-8c39-0d62956a6c2e", 
+            "heartbeat_front_addr": "10.214.137.138:6831/7335", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1049, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6828/7335", 
+            "up_thru": 1241, 
+            "cluster_addr": "10.214.137.138:6829/7335", 
+            "osd": 63
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6834/7811", 
+            "uuid": "2c66b078-8bd8-4fc1-8d36-ad01031f836c", 
+            "heartbeat_front_addr": "10.214.137.138:6835/7811", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1052, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6832/7811", 
+            "up_thru": 1575, 
+            "cluster_addr": "10.214.137.138:6833/7811", 
+            "osd": 64
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6838/8060", 
+            "uuid": "74c65390-c6f4-4733-936d-1620aeedc6ea", 
+            "heartbeat_front_addr": "10.214.137.138:6839/8060", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1053, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6836/8060", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.137.138:6837/8060", 
+            "osd": 65
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6842/8393", 
+            "uuid": "2695a0bc-8333-484d-9453-5ec63ba8dfab", 
+            "heartbeat_front_addr": "10.214.137.138:6843/8393", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1056, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6840/8393", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.137.138:6841/8393", 
+            "osd": 66
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6846/8736", 
+            "uuid": "87186dff-af18-44b9-a6aa-f34257b6519b", 
+            "heartbeat_front_addr": "10.214.137.138:6847/8736", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1058, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6844/8736", 
+            "up_thru": 1591, 
+            "cluster_addr": "10.214.137.138:6845/8736", 
+            "osd": 67
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6850/9187", 
+            "uuid": "705f5979-26fb-4d68-aaa6-2b895e597fe0", 
+            "heartbeat_front_addr": "10.214.137.138:6851/9187", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1061, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6848/9187", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.137.138:6849/9187", 
+            "osd": 68
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6854/9466", 
+            "uuid": "1e83b640-f9b1-4879-a5ed-dd98b55c1351", 
+            "heartbeat_front_addr": "10.214.137.138:6855/9466", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1063, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6852/9466", 
+            "up_thru": 1351, 
+            "cluster_addr": "10.214.137.138:6853/9466", 
+            "osd": 69
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6858/9747", 
+            "uuid": "7c447ff4-0f0b-4b09-bad6-20e162c85eab", 
+            "heartbeat_front_addr": "10.214.137.138:6859/9747", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1065, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6856/9747", 
+            "up_thru": 1334, 
+            "cluster_addr": "10.214.137.138:6857/9747", 
+            "osd": 70
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6862/10165", 
+            "uuid": "6013ddee-6540-4084-b4e2-4252dafff364", 
+            "heartbeat_front_addr": "10.214.137.138:6863/10165", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1068, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6860/10165", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.138:6861/10165", 
+            "osd": 71
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6866/10601", 
+            "uuid": "a5af7e3d-ae06-477f-a426-52fb8a205699", 
+            "heartbeat_front_addr": "10.214.137.138:6867/10601", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1071, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6864/10601", 
+            "up_thru": 1322, 
+            "cluster_addr": "10.214.137.138:6865/10601", 
+            "osd": 72
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6870/10895", 
+            "uuid": "5140f439-26b1-4612-8a73-02db43137f3b", 
+            "heartbeat_front_addr": "10.214.137.138:6871/10895", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1073, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6868/10895", 
+            "up_thru": 1585, 
+            "cluster_addr": "10.214.137.138:6869/10895", 
+            "osd": 73
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6874/11164", 
+            "uuid": "182285d8-5714-4ba3-822b-de80cdbe6dbb", 
+            "heartbeat_front_addr": "10.214.137.138:6875/11164", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1075, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6872/11164", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.137.138:6873/11164", 
+            "osd": 74
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6878/11503", 
+            "uuid": "39851140-c376-496e-a663-6fb4e17c3e7a", 
+            "heartbeat_front_addr": "10.214.137.138:6879/11503", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1077, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6876/11503", 
+            "up_thru": 1559, 
+            "cluster_addr": "10.214.137.138:6877/11503", 
+            "osd": 75
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6882/12003", 
+            "uuid": "4dd69fff-45b0-4db0-9365-196bf5f3cd63", 
+            "heartbeat_front_addr": "10.214.137.138:6883/12003", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1080, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6880/12003", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.137.138:6881/12003", 
+            "osd": 76
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6886/12228", 
+            "uuid": "c61df512-547f-4764-8568-d59a075c63dc", 
+            "heartbeat_front_addr": "10.214.137.138:6887/12228", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1081, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6884/12228", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.137.138:6885/12228", 
+            "osd": 77
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6890/12523", 
+            "uuid": "99255c6c-c999-426c-bc2d-359a8cb5d2a0", 
+            "heartbeat_front_addr": "10.214.137.138:6891/12523", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1083, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6888/12523", 
+            "up_thru": 1582, 
+            "cluster_addr": "10.214.137.138:6889/12523", 
+            "osd": 78
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6894/12869", 
+            "uuid": "9b7aec95-72de-48c4-adc3-c50768fdbd35", 
+            "heartbeat_front_addr": "10.214.137.138:6895/12869", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1085, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6892/12869", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.137.138:6893/12869", 
+            "osd": 79
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6898/13365", 
+            "uuid": "b1212a2a-3755-466e-af3f-56a89afc17da", 
+            "heartbeat_front_addr": "10.214.137.138:6899/13365", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1088, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6896/13365", 
+            "up_thru": 1584, 
+            "cluster_addr": "10.214.137.138:6897/13365", 
+            "osd": 80
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6902/13642", 
+            "uuid": "84ef4d6e-4153-4248-99a4-2b41d7625445", 
+            "heartbeat_front_addr": "10.214.137.138:6903/13642", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1090, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6900/13642", 
+            "up_thru": 1341, 
+            "cluster_addr": "10.214.137.138:6901/13642", 
+            "osd": 81
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6906/13922", 
+            "uuid": "93da10bb-7bb1-4520-8724-fb41f7a21a7c", 
+            "heartbeat_front_addr": "10.214.137.138:6907/13922", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1091, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6904/13922", 
+            "up_thru": 1577, 
+            "cluster_addr": "10.214.137.138:6905/13922", 
+            "osd": 82
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.138:6910/14195", 
+            "uuid": "b7552fdc-e54f-49b2-9c5b-d7736dce8a0c", 
+            "heartbeat_front_addr": "10.214.137.138:6911/14195", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1093, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.138:6908/14195", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.137.138:6909/14195", 
+            "osd": 83
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6802/28431", 
+            "uuid": "e8b7565e-8d0a-4644-b9f9-b5e50715ebe1", 
+            "heartbeat_front_addr": "10.214.137.120:6803/28431", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1096, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6800/28431", 
+            "up_thru": 1582, 
+            "cluster_addr": "10.214.137.120:6801/28431", 
+            "osd": 84
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6806/28710", 
+            "uuid": "65750b08-7b9c-49f0-a943-c1de733252dc", 
+            "heartbeat_front_addr": "10.214.137.120:6807/28710", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1098, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6804/28710", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.137.120:6805/28710", 
+            "osd": 85
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6810/28982", 
+            "uuid": "b2a72415-3e9a-496e-9021-53d86f1eb4ba", 
+            "heartbeat_front_addr": "10.214.137.120:6811/28982", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1100, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6808/28982", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.137.120:6809/28982", 
+            "osd": 86
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6814/29342", 
+            "uuid": "4d35f115-47c7-4dfb-91e3-61753614d7bc", 
+            "heartbeat_front_addr": "10.214.137.120:6815/29342", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1103, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6812/29342", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.137.120:6813/29342", 
+            "osd": 87
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6818/29794", 
+            "uuid": "0253546a-6708-4e93-b90d-ed534c5455a6", 
+            "heartbeat_front_addr": "10.214.137.120:6819/29794", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1106, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6816/29794", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.137.120:6817/29794", 
+            "osd": 88
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6822/30065", 
+            "uuid": "4c260ea4-578d-4617-b65e-496540035f7a", 
+            "heartbeat_front_addr": "10.214.137.120:6823/30065", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1108, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6820/30065", 
+            "up_thru": 1578, 
+            "cluster_addr": "10.214.137.120:6821/30065", 
+            "osd": 89
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6826/30403", 
+            "uuid": "4dfa55dd-ce49-456a-9c40-f841c4a78d2a", 
+            "heartbeat_front_addr": "10.214.137.120:6827/30403", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1110, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6824/30403", 
+            "up_thru": 1571, 
+            "cluster_addr": "10.214.137.120:6825/30403", 
+            "osd": 90
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6830/30688", 
+            "uuid": "6763cc4f-3aa3-4230-be4f-2214c7d8a1f3", 
+            "heartbeat_front_addr": "10.214.137.120:6831/30688", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1111, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6828/30688", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.120:6829/30688", 
+            "osd": 91
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6834/31196", 
+            "uuid": "1f772161-9e38-4cdf-8e71-09727858d635", 
+            "heartbeat_front_addr": "10.214.137.120:6835/31196", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1114, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6832/31196", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.137.120:6833/31196", 
+            "osd": 92
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6838/31450", 
+            "uuid": "3996696c-41a1-47e3-8b38-5621795c73fe", 
+            "heartbeat_front_addr": "10.214.137.120:6839/31450", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1115, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6836/31450", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.137.120:6837/31450", 
+            "osd": 93
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6842/31797", 
+            "uuid": "d0f6e5fb-a510-4bae-8901-42d31b5a63b5", 
+            "heartbeat_front_addr": "10.214.137.120:6843/31797", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1118, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6840/31797", 
+            "up_thru": 1241, 
+            "cluster_addr": "10.214.137.120:6841/31797", 
+            "osd": 94
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6846/32085", 
+            "uuid": "f35b2c8e-47d4-4699-b5ca-6d722cdbeea3", 
+            "heartbeat_front_addr": "10.214.137.120:6847/32085", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1120, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6844/32085", 
+            "up_thru": 1339, 
+            "cluster_addr": "10.214.137.120:6845/32085", 
+            "osd": 95
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6850/32585", 
+            "uuid": "f9ccba69-7193-42de-ab89-b64fb2bd980a", 
+            "heartbeat_front_addr": "10.214.137.120:6851/32585", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1123, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6848/32585", 
+            "up_thru": 1559, 
+            "cluster_addr": "10.214.137.120:6849/32585", 
+            "osd": 96
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6854/425", 
+            "uuid": "d8ffdc95-4fa1-4b77-bf49-7de8a1f86d8a", 
+            "heartbeat_front_addr": "10.214.137.120:6855/425", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1125, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6852/425", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.137.120:6853/425", 
+            "osd": 97
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6858/726", 
+            "uuid": "ae5fbae5-88dd-4249-a779-d7cdf443c361", 
+            "heartbeat_front_addr": "10.214.137.120:6859/726", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1127, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6856/726", 
+            "up_thru": 1591, 
+            "cluster_addr": "10.214.137.120:6857/726", 
+            "osd": 98
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6862/1055", 
+            "uuid": "a83eb213-48eb-492b-892a-67bde5db0ff4", 
+            "heartbeat_front_addr": "10.214.137.120:6863/1055", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1130, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6860/1055", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.137.120:6861/1055", 
+            "osd": 99
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6866/1575", 
+            "uuid": "64ef2625-cae7-4c36-8f00-2f8c812aaffc", 
+            "heartbeat_front_addr": "10.214.137.120:6867/1575", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1133, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6864/1575", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.120:6865/1575", 
+            "osd": 100
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6870/1831", 
+            "uuid": "cc271f03-47eb-40f7-a9a3-a6552f0d46af", 
+            "heartbeat_front_addr": "10.214.137.120:6871/1831", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1135, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6868/1831", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.137.120:6869/1831", 
+            "osd": 101
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6874/2203", 
+            "uuid": "11279d66-98fa-4589-8c85-956e07aebd13", 
+            "heartbeat_front_addr": "10.214.137.120:6875/2203", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1137, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6872/2203", 
+            "up_thru": 1339, 
+            "cluster_addr": "10.214.137.120:6873/2203", 
+            "osd": 102
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6878/2514", 
+            "uuid": "90483720-9c52-474c-854a-73224fd3c7a2", 
+            "heartbeat_front_addr": "10.214.137.120:6879/2514", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1139, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6876/2514", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.137.120:6877/2514", 
+            "osd": 103
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6882/3011", 
+            "uuid": "be4bdb85-9a4f-43c1-8883-7ce563059eef", 
+            "heartbeat_front_addr": "10.214.137.120:6883/3011", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1142, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6880/3011", 
+            "up_thru": 1591, 
+            "cluster_addr": "10.214.137.120:6881/3011", 
+            "osd": 104
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6886/3284", 
+            "uuid": "eeccb6a3-f6da-4ff7-bab9-96ed6ce219c7", 
+            "heartbeat_front_addr": "10.214.137.120:6887/3284", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1143, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6884/3284", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.137.120:6885/3284", 
+            "osd": 105
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6890/3610", 
+            "uuid": "2b355836-9ef2-46b8-b728-4a3b43b946d6", 
+            "heartbeat_front_addr": "10.214.137.120:6891/3610", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1145, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6888/3610", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.137.120:6889/3610", 
+            "osd": 106
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6894/3891", 
+            "uuid": "8f770490-17c9-43f2-ac67-b70babb78b91", 
+            "heartbeat_front_addr": "10.214.137.120:6895/3891", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1147, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6892/3891", 
+            "up_thru": 1584, 
+            "cluster_addr": "10.214.137.120:6893/3891", 
+            "osd": 107
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6898/4371", 
+            "uuid": "31aae19b-6ff0-4982-8149-487bc32abe5a", 
+            "heartbeat_front_addr": "10.214.137.120:6899/4371", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1150, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6896/4371", 
+            "up_thru": 1582, 
+            "cluster_addr": "10.214.137.120:6897/4371", 
+            "osd": 108
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6902/4654", 
+            "uuid": "700e3193-093a-41b0-b8ea-6f54ca04f7c7", 
+            "heartbeat_front_addr": "10.214.137.120:6903/4654", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1152, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6900/4654", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.137.120:6901/4654", 
+            "osd": 109
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6906/4922", 
+            "uuid": "373ab85c-cb92-4a5f-ba8f-db4871499518", 
+            "heartbeat_front_addr": "10.214.137.120:6907/4922", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1154, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6904/4922", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.137.120:6905/4922", 
+            "osd": 110
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.120:6910/5250", 
+            "uuid": "94811b15-bcae-4f6a-9fe8-65e274c3babd", 
+            "heartbeat_front_addr": "10.214.137.120:6911/5250", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1157, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.120:6908/5250", 
+            "up_thru": 1575, 
+            "cluster_addr": "10.214.137.120:6909/5250", 
+            "osd": 111
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6802/13077", 
+            "uuid": "5baff29b-e1a1-4d7e-be9c-e1a6dfcb0de8", 
+            "heartbeat_front_addr": "10.214.137.112:6803/13077", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1160, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6800/13077", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.137.112:6801/13077", 
+            "osd": 112
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6806/13348", 
+            "uuid": "beb831f4-2064-4d7a-a85f-bcadb10eec8f", 
+            "heartbeat_front_addr": "10.214.137.112:6807/13348", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1162, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6804/13348", 
+            "up_thru": 1575, 
+            "cluster_addr": "10.214.137.112:6805/13348", 
+            "osd": 113
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6810/13688", 
+            "uuid": "9a3b34b2-f201-4699-bc4d-f09ca0a3f19b", 
+            "heartbeat_front_addr": "10.214.137.112:6811/13688", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1164, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6808/13688", 
+            "up_thru": 1582, 
+            "cluster_addr": "10.214.137.112:6809/13688", 
+            "osd": 114
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6814/14007", 
+            "uuid": "090b69d9-413a-4eda-a1fd-9e75d7f14d10", 
+            "heartbeat_front_addr": "10.214.137.112:6815/14007", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1167, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6812/14007", 
+            "up_thru": 1375, 
+            "cluster_addr": "10.214.137.112:6813/14007", 
+            "osd": 115
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6818/14463", 
+            "uuid": "153cd5f4-689e-4259-ab0f-a95fdbe943af", 
+            "heartbeat_front_addr": "10.214.137.112:6819/14463", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1170, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6816/14463", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.137.112:6817/14463", 
+            "osd": 116
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6822/14746", 
+            "uuid": "73aeef1d-d420-4f80-b7b8-6c3428a5fc5d", 
+            "heartbeat_front_addr": "10.214.137.112:6823/14746", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1173, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6820/14746", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.137.112:6821/14746", 
+            "osd": 117
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6826/15056", 
+            "uuid": "8fd73ed2-7e1b-4ddf-b703-eb42c83ad6c9", 
+            "heartbeat_front_addr": "10.214.137.112:6827/15056", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1176, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6824/15056", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.137.112:6825/15056", 
+            "osd": 118
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6830/15375", 
+            "uuid": "733eb7d9-3779-4acd-a035-93ccfeeeb757", 
+            "heartbeat_front_addr": "10.214.137.112:6831/15375", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1178, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6828/15375", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.137.112:6829/15375", 
+            "osd": 119
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6834/15838", 
+            "uuid": "f0f847b2-83c5-45e0-9e77-f2850e4bf202", 
+            "heartbeat_front_addr": "10.214.137.112:6835/15838", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1181, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6832/15838", 
+            "up_thru": 1348, 
+            "cluster_addr": "10.214.137.112:6833/15838", 
+            "osd": 120
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6838/16158", 
+            "uuid": "cde6f94a-c45b-4911-b43a-82c33c4d884f", 
+            "heartbeat_front_addr": "10.214.137.112:6839/16158", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1183, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6836/16158", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.137.112:6837/16158", 
+            "osd": 121
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6842/16473", 
+            "uuid": "5297b3ec-00b8-4453-bac7-44bee8e80c30", 
+            "heartbeat_front_addr": "10.214.137.112:6843/16473", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1185, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6840/16473", 
+            "up_thru": 1573, 
+            "cluster_addr": "10.214.137.112:6841/16473", 
+            "osd": 122
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6846/16721", 
+            "uuid": "463ebe4c-0309-4ace-9ad6-c8af02972cc7", 
+            "heartbeat_front_addr": "10.214.137.112:6847/16721", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1187, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6844/16721", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.137.112:6845/16721", 
+            "osd": 123
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6850/17213", 
+            "uuid": "fffc3ff2-4160-4288-9b27-4ea2db1a182a", 
+            "heartbeat_front_addr": "10.214.137.112:6851/17213", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1190, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6848/17213", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.137.112:6849/17213", 
+            "osd": 124
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6854/17487", 
+            "uuid": "4db137f4-50a8-40ac-9688-c2ae370a0f2d", 
+            "heartbeat_front_addr": "10.214.137.112:6855/17487", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1191, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6852/17487", 
+            "up_thru": 1319, 
+            "cluster_addr": "10.214.137.112:6853/17487", 
+            "osd": 125
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6858/17833", 
+            "uuid": "d85ce0bb-e30c-478f-b2fe-e915a4f738cc", 
+            "heartbeat_front_addr": "10.214.137.112:6859/17833", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1193, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6856/17833", 
+            "up_thru": 1241, 
+            "cluster_addr": "10.214.137.112:6857/17833", 
+            "osd": 126
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6862/18085", 
+            "uuid": "0a964a04-4e39-4137-bbcb-8022d4e1aa98", 
+            "heartbeat_front_addr": "10.214.137.112:6863/18085", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1195, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6860/18085", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.137.112:6861/18085", 
+            "osd": 127
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6866/18567", 
+            "uuid": "11f82796-04a5-48e5-861e-14c8811b7ed9", 
+            "heartbeat_front_addr": "10.214.137.112:6867/18567", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1198, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6864/18567", 
+            "up_thru": 1581, 
+            "cluster_addr": "10.214.137.112:6865/18567", 
+            "osd": 128
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6870/18845", 
+            "uuid": "538dae83-ef2b-46ef-b0e5-42984b9fecac", 
+            "heartbeat_front_addr": "10.214.137.112:6871/18845", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1199, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6868/18845", 
+            "up_thru": 1580, 
+            "cluster_addr": "10.214.137.112:6869/18845", 
+            "osd": 129
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6874/19171", 
+            "uuid": "ff6a8368-f5ae-43ee-8b05-4056652b0b34", 
+            "heartbeat_front_addr": "10.214.137.112:6875/19171", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1201, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6872/19171", 
+            "up_thru": 1418, 
+            "cluster_addr": "10.214.137.112:6873/19171", 
+            "osd": 130
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6878/19478", 
+            "uuid": "1ffc63ef-d229-446b-8003-70e63c329c7a", 
+            "heartbeat_front_addr": "10.214.137.112:6879/19478", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1203, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6876/19478", 
+            "up_thru": 1561, 
+            "cluster_addr": "10.214.137.112:6877/19478", 
+            "osd": 131
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6882/19916", 
+            "uuid": "fcaa954c-cf20-4001-8248-80c728f5633e", 
+            "heartbeat_front_addr": "10.214.137.112:6883/19916", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1206, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6880/19916", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.112:6881/19916", 
+            "osd": 132
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6886/20196", 
+            "uuid": "3ddb6374-7a13-4530-bc99-3ec9b844cfee", 
+            "heartbeat_front_addr": "10.214.137.112:6887/20196", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1207, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6884/20196", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.112:6885/20196", 
+            "osd": 133
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6890/20538", 
+            "uuid": "c5ba3b76-635c-4a19-b3cb-4443f52bdbd1", 
+            "heartbeat_front_addr": "10.214.137.112:6891/20538", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1209, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6888/20538", 
+            "up_thru": 1575, 
+            "cluster_addr": "10.214.137.112:6889/20538", 
+            "osd": 134
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6894/20791", 
+            "uuid": "ab3bdfbb-ae1f-4c86-bb4e-5c5e7952bc2c", 
+            "heartbeat_front_addr": "10.214.137.112:6895/20791", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1211, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6892/20791", 
+            "up_thru": 1523, 
+            "cluster_addr": "10.214.137.112:6893/20791", 
+            "osd": 135
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6898/21283", 
+            "uuid": "fac8605a-dc7a-43eb-8dc1-2b6dbf1e34fc", 
+            "heartbeat_front_addr": "10.214.137.112:6899/21283", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1214, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6896/21283", 
+            "up_thru": 1602, 
+            "cluster_addr": "10.214.137.112:6897/21283", 
+            "osd": 136
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6902/21563", 
+            "uuid": "2dcf34d4-96b6-4177-8140-2970865754be", 
+            "heartbeat_front_addr": "10.214.137.112:6903/21563", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1215, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6900/21563", 
+            "up_thru": 1604, 
+            "cluster_addr": "10.214.137.112:6901/21563", 
+            "osd": 137
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6906/21799", 
+            "uuid": "92ddad58-cb82-4862-81f0-9d8d79448eae", 
+            "heartbeat_front_addr": "10.214.137.112:6907/21799", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1216, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6904/21799", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.137.112:6905/21799", 
+            "osd": 138
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.137.112:6910/22175", 
+            "uuid": "dace112a-369a-470a-9f55-1e22c48c7736", 
+            "heartbeat_front_addr": "10.214.137.112:6911/22175", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1218, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.137.112:6908/22175", 
+            "up_thru": 1591, 
+            "cluster_addr": "10.214.137.112:6909/22175", 
+            "osd": 139
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6913/1013114", 
+            "uuid": "0aab7e07-9a24-424c-a183-b076f9ec262d", 
+            "heartbeat_front_addr": "10.214.133.116:6914/1013114", 
+            "down_at": 1364, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1367, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1323, 
+            "last_clean_end": 1366, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6816/13114", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.133.116:6912/1013114", 
+            "osd": 140
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6886/20459", 
+            "uuid": "9e2ece86-8a28-40f0-8cbf-6f32460fe1ce", 
+            "heartbeat_front_addr": "10.214.133.116:6887/20459", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1334, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1249, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6884/20459", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.133.116:6885/20459", 
+            "osd": 141
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6894/21519", 
+            "uuid": "cd58ab08-ffc0-458f-8e61-af4e858cea64", 
+            "heartbeat_front_addr": "10.214.133.116:6895/21519", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1336, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1250, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6892/21519", 
+            "up_thru": 1584, 
+            "cluster_addr": "10.214.133.116:6893/21519", 
+            "osd": 142
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6830/14122", 
+            "uuid": "6f09a081-ba20-4530-b6c3-3d6e3f0f322a", 
+            "heartbeat_front_addr": "10.214.133.116:6831/14122", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1324, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1252, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6828/14122", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.133.116:6829/14122", 
+            "osd": 143
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6870/18887", 
+            "uuid": "493e7bea-08ee-4e91-98e4-afa56ad6d7f6", 
+            "heartbeat_front_addr": "10.214.133.116:6871/18887", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1332, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1256, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6868/18887", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.133.116:6869/18887", 
+            "osd": 144
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6866/18240", 
+            "uuid": "520266fc-79c6-404f-ae06-000ec6a2c759", 
+            "heartbeat_front_addr": "10.214.133.116:6867/18240", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1331, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1260, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6864/18240", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.133.116:6865/18240", 
+            "osd": 145
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6810/12592", 
+            "uuid": "9242c5c4-15c4-487d-a616-43c37f91df5d", 
+            "heartbeat_front_addr": "10.214.133.116:6811/12592", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1322, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1260, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6808/12592", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.133.116:6809/12592", 
+            "osd": 146
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6862/17511", 
+            "uuid": "9d10e0b0-1fd7-4eb3-a826-c69f24ff8e97", 
+            "heartbeat_front_addr": "10.214.133.116:6863/17511", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1329, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1264, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6860/17511", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.133.116:6861/17511", 
+            "osd": 147
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6838/15418", 
+            "uuid": "992d5a70-f1b9-4b19-ad20-1f5a6b5523ea", 
+            "heartbeat_front_addr": "10.214.133.116:6839/15418", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1327, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1270, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6836/15418", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.133.116:6837/15418", 
+            "osd": 148
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6826/14068", 
+            "uuid": "e55f7d6d-5f57-43dc-8526-4a4d1e0f9008", 
+            "heartbeat_front_addr": "10.214.133.116:6827/14068", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1325, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1269, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6824/14068", 
+            "up_thru": 1599, 
+            "cluster_addr": "10.214.133.116:6825/14068", 
+            "osd": 149
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6834/14856", 
+            "uuid": "e9e893d7-86e3-431b-9d54-bd4a004f0ef3", 
+            "heartbeat_front_addr": "10.214.133.116:6835/14856", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1327, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1273, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6832/14856", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.133.116:6833/14856", 
+            "osd": 150
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6850/16209", 
+            "uuid": "c9f9791d-fb62-486c-90f2-65f778616cc8", 
+            "heartbeat_front_addr": "10.214.133.116:6851/16209", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1327, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1276, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6848/16209", 
+            "up_thru": 1597, 
+            "cluster_addr": "10.214.133.116:6849/16209", 
+            "osd": 151
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6802/12368", 
+            "uuid": "ad807c61-29ab-44e1-ae56-0da82f33fa76", 
+            "heartbeat_front_addr": "10.214.133.116:6803/12368", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1321, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1277, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6800/12368", 
+            "up_thru": 1610, 
+            "cluster_addr": "10.214.133.116:6801/12368", 
+            "osd": 152
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6854/16477", 
+            "uuid": "b5ab93d7-66ad-4cb3-9e6b-359243f3352f", 
+            "heartbeat_front_addr": "10.214.133.116:6855/16477", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1329, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1281, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6852/16477", 
+            "up_thru": 1591, 
+            "cluster_addr": "10.214.133.116:6853/16477", 
+            "osd": 153
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6842/15617", 
+            "uuid": "cc703628-7202-43b1-a8ab-beaf47be2f08", 
+            "heartbeat_front_addr": "10.214.133.116:6843/15617", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1327, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1284, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6840/15617", 
+            "up_thru": 1581, 
+            "cluster_addr": "10.214.133.116:6841/15617", 
+            "osd": 154
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6846/15748", 
+            "uuid": "6793c223-2919-482f-8f8e-a0db83f4e806", 
+            "heartbeat_front_addr": "10.214.133.116:6847/15748", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1327, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1287, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6844/15748", 
+            "up_thru": 1575, 
+            "cluster_addr": "10.214.133.116:6845/15748", 
+            "osd": 155
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6882/19592", 
+            "uuid": "7cbf580e-baad-4593-b4c9-ea26b8f8f38c", 
+            "heartbeat_front_addr": "10.214.133.116:6883/19592", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1332, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1291, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6880/19592", 
+            "up_thru": 1580, 
+            "cluster_addr": "10.214.133.116:6881/19592", 
+            "osd": 156
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6806/12451", 
+            "uuid": "1c1667f5-806f-45f8-890e-dfd783e34867", 
+            "heartbeat_front_addr": "10.214.133.116:6807/12451", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1321, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1295, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6804/12451", 
+            "up_thru": 1589, 
+            "cluster_addr": "10.214.133.116:6805/12451", 
+            "osd": 157
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6858/17362", 
+            "uuid": "36d10179-ce77-4594-8d50-7b8543078dae", 
+            "heartbeat_front_addr": "10.214.133.116:6859/17362", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1329, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1298, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6856/17362", 
+            "up_thru": 1571, 
+            "cluster_addr": "10.214.133.116:6857/17362", 
+            "osd": 158
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6822/13430", 
+            "uuid": "bc7f4bbe-3268-4d48-89b1-a665ddf6d30f", 
+            "heartbeat_front_addr": "10.214.133.116:6823/13430", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1323, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1302, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6820/13430", 
+            "up_thru": 1561, 
+            "cluster_addr": "10.214.133.116:6821/13430", 
+            "osd": 159
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6878/19515", 
+            "uuid": "728415ac-081f-4bb6-aadd-eb85a4198f16", 
+            "heartbeat_front_addr": "10.214.133.116:6879/19515", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1332, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1303, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6876/19515", 
+            "up_thru": 1351, 
+            "cluster_addr": "10.214.133.116:6877/19515", 
+            "osd": 160
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6814/12818", 
+            "uuid": "f65b4cdd-042e-43dd-ab3c-efda6655530a", 
+            "heartbeat_front_addr": "10.214.133.116:6815/12818", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1322, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1307, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6812/12818", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.133.116:6813/12818", 
+            "osd": 161
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6874/19041", 
+            "uuid": "16f63c42-9241-4e80-872e-1be8c1e09ade", 
+            "heartbeat_front_addr": "10.214.133.116:6875/19041", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1331, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1311, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6872/19041", 
+            "up_thru": 1585, 
+            "cluster_addr": "10.214.133.116:6873/19041", 
+            "osd": 162
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6890/21151", 
+            "uuid": "649477e2-5851-47d5-bc3d-4271ac48189a", 
+            "heartbeat_front_addr": "10.214.133.116:6891/21151", 
+            "down_at": 1316, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1334, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 1314, 
+            "last_clean_end": 1315, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6888/21151", 
+            "up_thru": 1587, 
+            "cluster_addr": "10.214.133.116:6889/21151", 
+            "osd": 163
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6898/28251", 
+            "uuid": "03a909c5-51b6-4f4d-9ae8-e3790fb55e7c", 
+            "heartbeat_front_addr": "10.214.133.116:6899/28251", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1341, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6896/28251", 
+            "up_thru": 1563, 
+            "cluster_addr": "10.214.133.116:6897/28251", 
+            "osd": 164
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6902/32151", 
+            "uuid": "9631feb3-863a-409b-9d89-3ba6d4ddd849", 
+            "heartbeat_front_addr": "10.214.133.116:6903/32151", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1345, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6900/32151", 
+            "up_thru": 1608, 
+            "cluster_addr": "10.214.133.116:6901/32151", 
+            "osd": 165
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6906/777", 
+            "uuid": "108fbb39-6215-4bfe-9549-b767bfeda158", 
+            "heartbeat_front_addr": "10.214.133.116:6907/777", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1348, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6904/777", 
+            "up_thru": 1348, 
+            "cluster_addr": "10.214.133.116:6905/777", 
+            "osd": 166
+        }, 
+        {
+            "heartbeat_back_addr": "10.214.133.116:6910/3267", 
+            "uuid": "646acad4-cee9-4896-9378-ca2e3480067f", 
+            "heartbeat_front_addr": "10.214.133.116:6911/3267", 
+            "down_at": 0, 
+            "up": 1, 
+            "lost_at": 0, 
+            "up_from": 1352, 
+            "state": [
+                "exists", 
+                "up"
+            ], 
+            "last_clean_begin": 0, 
+            "last_clean_end": 0, 
+            "in": 1, 
+            "public_addr": "10.214.133.116:6908/3267", 
+            "up_thru": 1606, 
+            "cluster_addr": "10.214.133.116:6909/3267", 
+            "osd": 167
+        }
+    ], 
+    "blacklist": [], 
+    "epoch": 1611, 
+    "pg_temp": [], 
+    "flags": "", 
+    "cluster_snapshot": "", 
+    "pools": [
+        {
+            "snap_seq": 0, 
+            "pool_name": "data", 
+            "snap_mode": "selfmanaged", 
+            "auid": 0, 
+            "last_change": "1229", 
+            "pool_snaps": {}, 
+            "quota_max_objects": 0, 
+            "quota_max_bytes": 0, 
+            "pg_placement_num": 2048, 
+            "min_size": 1, 
+            "removed_snaps": "[]", 
+            "crash_replay_interval": 45, 
+            "object_hash": 2, 
+            "flags": 0, 
+            "pg_num": 2048, 
+            "snap_epoch": 0, 
+            "crush_ruleset": 0, 
+            "type": 1, 
+            "pool": 0, 
+            "size": 2
+        }, 
+        {
+            "snap_seq": 0, 
+            "pool_name": "metadata", 
+            "snap_mode": "selfmanaged", 
+            "auid": 0, 
+            "last_change": "1234", 
+            "pool_snaps": {}, 
+            "quota_max_objects": 0, 
+            "quota_max_bytes": 0, 
+            "pg_placement_num": 2048, 
+            "min_size": 1, 
+            "removed_snaps": "[]", 
+            "crash_replay_interval": 0, 
+            "object_hash": 2, 
+            "flags": 0, 
+            "pg_num": 2048, 
+            "snap_epoch": 0, 
+            "crush_ruleset": 1, 
+            "type": 1, 
+            "pool": 1, 
+            "size": 2
+        }, 
+        {
+            "snap_seq": 0, 
+            "pool_name": "rbd", 
+            "snap_mode": "selfmanaged", 
+            "auid": 0, 
+            "last_change": "1239", 
+            "pool_snaps": {}, 
+            "quota_max_objects": 0, 
+            "quota_max_bytes": 0, 
+            "pg_placement_num": 2048, 
+            "min_size": 1, 
+            "removed_snaps": "[]", 
+            "crash_replay_interval": 0, 
+            "object_hash": 2, 
+            "flags": 0, 
+            "pg_num": 2048, 
+            "snap_epoch": 0, 
+            "crush_ruleset": 2, 
+            "type": 1, 
+            "pool": 2, 
+            "size": 2
+        }
+    ], 
+    "fsid": "61723e0f-992b-466e-9c09-9914931bc584"
+}

--- a/cthulhu/tests/test_osd_map.py
+++ b/cthulhu/tests/test_osd_map.py
@@ -41,3 +41,23 @@ class TestOsdMap(TestCase):
             6: first_osds,
             7: first_server_osds
         })
+
+    def test_7883(self):
+        """
+        Bug in which pools were not found for OSDs
+        """
+        osd_map = OsdMap(None, load_fixture("osd_map-7883.json"))
+        all_osds = osd_map.osds_by_id.keys()
+        self.assertEqual(len(all_osds), 168)
+
+        self.assertDictEqual(osd_map.osds_by_rule_id, {
+            0: all_osds,
+            1: all_osds,
+            2: all_osds
+        })
+
+        self.assertDictEqual(osd_map.osds_by_pool, {
+            0: all_osds,
+            1: all_osds,
+            2: all_osds
+        })


### PR DESCRIPTION
The CRUSH rule code was expecting choose_firstn operations
to be choosing direct children, but it should have been
looking for all descendents.

For example, when firstn is used on a hierarchy of
root->hosts->osds, a rule that uses "choose firstn 0 osd"
from the root would get all the osds.

Fixes: #7883
