### PR TITLE
cthulhu: send pings to late minions

### DIFF
--- a/conf/calamari.conf
+++ b/conf/calamari.conf
@@ -4,19 +4,17 @@
 plugin_path = /opt/calamari/plugins # TODO add to packaging, not a problem now since we check os.path.exists
 salt_config_path = /etc/salt/master
 alembic_config_path = /etc/calamari/alembic.ini
-# FIXME: this should be a function of the ceph.heartbeat schedule period which
-# we should query from the salt pillar
-favorite_timeout_s = 60
 db_path = postgresql://calamari:27HbZwr*g@localhost/calamari
 log_path = /var/log/calamari/cthulhu.log
 log_level = WARN
 rpc_url = tcp://127.0.0.1:5050
 crush_host_type = host
 crush_osd_type = osd
-server_contact_threshold = 120
-cluster_contact_threshold = 60
 cluster_map_retention = 3600
 db_log_level = WARN
+favorite_timeout_factor = 3
+server_timeout_factor = 3
+cluster_contact_threshold = 60
 
 [calamari_web]
 

--- a/dev/calamari.conf.template
+++ b/dev/calamari.conf.template
@@ -4,19 +4,17 @@
 plugin_path = {{calamari_root}}/cthulhu/tests/plugins
 salt_config_path = {{calamari_root}}/dev/etc/salt/master
 alembic_config_path = {{calamari_root}}/dev/alembic.ini
-# FIXME: this should be a function of the ceph.heartbeat schedule period which
-# we should query from the salt pillar
-favorite_timeout_s = 60
 db_path = postgresql://calamari:27HbZwr*g@localhost/calamari
 log_path = {{calamari_root}}/dev/cthulhu.log
 log_level = DEBUG
 rpc_url = tcp://127.0.0.1:5050
 crush_host_type = host
 crush_osd_type = osd
-server_contact_threshold = 120
-cluster_contact_threshold = 60
 cluster_map_retention = 3600
 db_log_level = WARN
+favorite_timeout_factor = 3
+server_timeout_factor = 3
+cluster_contact_threshold = 60
 
 [calamari_web]
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 # This equals the period in schedules.sls
-HEARTBEAT_PERIOD = 30
+HEARTBEAT_PERIOD = 10
 
 
 # This is how long after mon going dark the cluster monitor


### PR DESCRIPTION
This is a bit hacky, but necessary.  The problem is
that when the salt master AES key changes, minions don't
clue in until they receive a message they don't understand.
Our minions are mostly only sending messages, not receiving
them, so don't learn about the new key.  The workaround is
to send a ping to any minions that seem to have gone quiet,
hopefully in time for them to learn about the new key
before generating any spurious "server lost contact"
type alerts.

The alternative would be to do full PKI negotiation on
every event with all the CPU cycles and roundtrips that
that entails.  We may see a better solution in the long
run as salt adds crypto at the transport level.

Because this change makes us functionally dependent on
the expected contact interval, not just for alerting, now
is the time to make the interval robustly defined via
the scheduled interval in the pillar, rather than via
an absolute time in a config setting, so do that to.

Fixes: #7836
