### PR TITLE
conf/salt.master.conf: Allow client to run log_tail

### DIFF
--- a/conf/salt.master.conf
+++ b/conf/salt.master.conf
@@ -10,3 +10,12 @@ pillar_roots:
 reactor:
   - 'salt/minion/*/start':
     - /opt/calamari/salt/reactor/start.sls
+
+# add both the Debian default apache user and the RedHat one to
+# avoid making this file distro-dependent
+
+client_acl:
+  www-data:
+    - log_tail.*
+  apache:
+    - log_tail.*


### PR DESCRIPTION
log_tail is run as a LocalClient instance from the Django app, and as
such needs permission to run Salt commands as the web user.
Note: both www-user and apache added to keep this file distro-neutral.

Fixes: #7691
Signed-off-by: Dan Mick dan.mick@inktank.com
