### PR TITLE
cthulhu: work around salt-master connection issues

### DIFF
--- a/cthulhu/cthulhu/manager/cluster_monitor.py
+++ b/cthulhu/cthulhu/manager/cluster_monitor.py
@@ -25,7 +25,7 @@ from cthulhu.manager.plugin_monitor import PluginMonitor
 from calamari_common.types import SYNC_OBJECT_STR_TYPE, SYNC_OBJECT_TYPES, OSD, POOL, OsdMap, MdsMap, MonMap
 from cthulhu.manager.request_collection import RequestCollection
 from cthulhu.manager import config, salt_config
-from cthulhu.util import now, Ticker
+from cthulhu.util import now, Ticker, SaltEventSource
 
 
 FAVORITE_TIMEOUT_FACTOR = int(config.get('cthulhu', 'favorite_timeout_factor'))
@@ -245,7 +245,7 @@ class ClusterMonitor(gevent.greenlet.Greenlet):
         log.debug("ClusterMonitor._run: ready")
 
         self._request_ticker.start()
-        event = salt.utils.event.MasterEvent(salt_config['sock_dir'])
+        event = SaltEventSource(salt_config)
 
         while not self._complete.is_set():
             # No salt tag filtering: https://github.com/saltstack/salt/issues/11582

--- a/cthulhu/cthulhu/manager/manager.py
+++ b/cthulhu/cthulhu/manager/manager.py
@@ -14,7 +14,6 @@ import gevent.greenlet
 import manhole
 import msgpack
 import resource
-import salt.utils.event
 import sys
 
 import sqlalchemy.exc
@@ -33,6 +32,7 @@ from cthulhu.persistence.servers import Server, Service
 
 from cthulhu.persistence.sync_objects import SyncObject
 from cthulhu.persistence.persister import Persister, Session
+from cthulhu.util import SaltEventSource
 
 
 class ProcessMonitorThread(gevent.greenlet.Greenlet):
@@ -97,7 +97,7 @@ class DiscoveryThread(gevent.greenlet.Greenlet):
     def _run(self):
         log.info("%s running" % self.__class__.__name__)
 
-        event = salt.utils.event.MasterEvent(salt_config['sock_dir'])
+        event = SaltEventSource(salt_config)
         while not self._complete.is_set():
             # No salt tag filtering: https://github.com/saltstack/salt/issues/11582
             ev = event.get_event(full=True)

--- a/cthulhu/cthulhu/manager/server_monitor.py
+++ b/cthulhu/cthulhu/manager/server_monitor.py
@@ -24,7 +24,7 @@ from cthulhu.manager import salt_config, config
 # own crush map they may have changed this), Ceph defaults are 'host' and 'osd'
 from calamari_common.types import OsdMap, MonMap, ServiceId
 from cthulhu.persistence.servers import Server, Service
-from cthulhu.util import now
+from cthulhu.util import now, SaltEventSource
 
 CRUSH_HOST_TYPE = config.get('cthulhu', 'crush_host_type')
 CRUSH_OSD_TYPE = config.get('cthulhu', 'crush_osd_type')
@@ -144,7 +144,7 @@ class ServerMonitor(greenlet.Greenlet):
     def _run(self):
         log.info("Starting %s" % self.__class__.__name__)
 
-        subscription = salt.utils.event.MasterEvent(salt_config['sock_dir'])
+        subscription = SaltEventSource(salt_config)
 
         last_tick = time.time()
 

--- a/cthulhu/cthulhu/util.py
+++ b/cthulhu/cthulhu/util.py
@@ -3,6 +3,9 @@ import datetime
 from dateutil import tz
 import gevent.greenlet
 import gevent.event
+from cthulhu.log import log
+
+import salt.utils.event
 
 
 def now():
@@ -26,3 +29,51 @@ class Ticker(gevent.greenlet.Greenlet):
         while not self._complete.is_set():
             self._callback()
             self._complete.wait(self._period)
+
+
+class SaltEventSource(object):
+    """
+    A wrapper around salt's MasterEvent class that closes and re-opens
+    the connection if it goes quiet for too long, to ward off mysterious
+    silent-death of communications (#8144)
+    """
+
+    # Not a logical timeout, just how long we stick inside a get_event call
+    POLL_TIMEOUT = 5
+
+    # After this long without messages, close and reopen out connection to
+    # salt-master.  Don't want to do this gratuitously because it can drop
+    # messages during the cutover (lossiness is functionally OK but user
+    # might notice).
+    SILENCE_TIMEOUT = 20
+
+    def __init__(self, config):
+        """
+        :param config: a salt client_config instance
+        """
+        self._silence_counter = 0
+        self._config = config
+        self._master_event = salt.utils.event.MasterEvent(self._config['sock_dir'])
+
+    def _destroy_conn(self, old_ev):
+        old_ev.destroy()
+
+    def get_event(self, *args, **kwargs):
+        """
+        Wrap MasterEvent.get_event
+        """
+        ev = self._master_event.get_event(self.POLL_TIMEOUT, *args, **kwargs)
+        if ev is None:
+            self._silence_counter += self.POLL_TIMEOUT
+            if self._silence_counter > self.SILENCE_TIMEOUT:
+                log.warning("Re-opening connection to salt-master")
+
+                self._silence_counter = 0
+                # Re-open the connection as a precaution against this lack of
+                # messages being a symptom of a connection that has gone bad.
+                old_ev = self._master_event
+                gevent.spawn(lambda: self._destroy_conn(old_ev))
+                self._master_event = salt.utils.event.MasterEvent(self._config['sock_dir'])
+        else:
+            self._silence_counter = 0
+            return ev


### PR DESCRIPTION
Because we have an as-yet-unexplained silent death
of the connection between cthulhu and salt-master,
we will now re-open the connection each time we
have pass through a poll interval with no messages.
