### PR TITLE
Fixes test_mon_down test failure

### DIFF
--- a/tests/test.conf.template
+++ b/tests/test.conf.template
@@ -4,7 +4,7 @@
 calamari_control = embedded
 ceph_control = embedded
 
-embedded_wait_timeout = 10
-external_wait_timeout = 60
+embedded_timeout_factor = 1
+external_timeout_factor = 6
 
 external_cluster_path = {{calamari_root}}/../teuthology/archive/cluster.yaml

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,21 +5,23 @@ from tests.config import TestConfig
 config = TestConfig()
 
 
-def get_timeout():
-    timeout = config.get('testing', 'embedded_wait_timeout')
+def get_timeout_scaling_factor():
+    factor = 1
     if config.get('testing', 'ceph_control') == 'external':
-        timeout = config.get('testing', 'external_wait_timeout')
-
-    return timeout
+        factor = config.get('testing', 'external_timeout_factor')
+    elif config.get('testing', 'ceph_control') == 'embedded':
+        factor = config.get('testing', 'embedded_timeout_factor')
+    return factor
 
 
 class WaitTimeout(Exception):
     pass
 
 
-def wait_until_true(condition, timeout=get_timeout()):
+def wait_until_true(condition, timeout=10):
     elapsed = 0
     period = 1
+    timeout = timeout * get_timeout_scaling_factor()
     while not condition():
         if elapsed >= timeout:
             raise WaitTimeout("After %s seconds (at %s)" % (elapsed, datetime.datetime.utcnow().isoformat()))


### PR DESCRIPTION
@jcsp Looks like this bug was really just the result of a marginal timeout.
I provided a scaling factor in the test config to address this
