### PR TITLE
Cleans up after wip-8050 landed in teuthology

### DIFF
--- a/doc/development/testing.rst
+++ b/doc/development/testing.rst
@@ -89,7 +89,7 @@ Test that you have a working step 1:
 
     cd /home/vagrant/teuthology
     source virtualenv/bin/activate
-    grep -o "^.*\.front\.sepia\.ceph\.com" archive/config.yaml |\
+    grep -o "^.*\.front\.sepia\.ceph\.com" archive/info.yaml |\
         xargs -I'{}' ssh '{}' "if [ -e /etc/ceph/ceph.client.0.keyring ]; then ceph health; fi"
 
 
@@ -97,12 +97,12 @@ Step 2: Testing setup
 ^^^^^^^^^^^^^^^^^^^^^
 
 There are a few manual changes you'll need to make to test against this cluster:
-- Add a master_fqdn dict to teuthology/archive/cluster.yaml like:
+- Add a master_fqdn dict to teuthology/archive/info.yaml like:
 .. code-block:: yaml
     master_fqdn:
         <FQDN of the machine where you are running a calmari devmode instance>
 
-- Edit dev/calamari.conf changing ceph_control under testing to 'external'
+- Edit tests/tests.conf changing ceph_control under testing to 'external'
 .. code-block:: yaml
     [testing]
         ceph_control = external
@@ -133,7 +133,7 @@ Hit Ctrl-D in the teuthology session
     cd /home/vagrant/teuthology
     source virtualenv/bin/activate
     teuthology-lock --list-targets --owner calamari@inktank.com |\
-     teuthology-nuke -t /dev/stdin -ru --owner=calamari@inktank.com
+     teuthology-nuke -t /dev/stdin -u --owner=calamari@inktank.com
 
 .. _troubleshooting:
 

--- a/tests/ceph_ctl.py
+++ b/tests/ceph_ctl.py
@@ -300,7 +300,7 @@ class ExternalCephControl(CephControl):
 
     def _get_admin_node(self):
         for target, roles in self.config['cluster'].iteritems():
-            if 'client.0' in roles:
+            if 'client.0' in roles['roles']:
                 return target.split('@')[1]
 
     def mark_osd_in(self, fsid, osd_id, osd_in=True):

--- a/tests/test.conf.template
+++ b/tests/test.conf.template
@@ -7,4 +7,4 @@ ceph_control = embedded
 embedded_timeout_factor = 1
 external_timeout_factor = 6
 
-external_cluster_path = {{calamari_root}}/../teuthology/archive/cluster.yaml
+external_cluster_path = {{calamari_root}}/../teuthology/archive/info.yaml

--- a/vagrant/devmode/salt/roots/git_clone.sls
+++ b/vagrant/devmode/salt/roots/git_clone.sls
@@ -10,6 +10,7 @@ git_clone:
 git_clone_teuthology:
   git:
     - latest
+    - rev: 5339c1f2ee
     - user: vagrant
     - target: /home/vagrant/teuthology
     - name: https://github.com/ceph/teuthology.git


### PR DESCRIPTION
@dmick 
@jcsp 
Only thing to note here is that I feel pretty strongly about tagging teuthology to preserve history integrity in git_clone.sls:13
