### PR TITLE
Fixes bulk_update not returning errors from validation

### DIFF
--- a/rest-api/calamari_rest/views/v2.py
+++ b/rest-api/calamari_rest/views/v2.py
@@ -153,10 +153,10 @@ Calamari accepts messages from a server, the server's key must be accepted.
     def _validate_list(self, request):
         keys = request.DATA
         if not isinstance(keys, list):
-            return Response("Bulk PATCH must send a list", status=status.HTTP_400_BAD_REQUEST)
+            raise ParseError("Bulk PATCH must send a list")
         for key in keys:
             if 'id' not in key:
-                return Response("Items in bulk PATCH must have 'id' attribute", status=status.HTTP_400_BAD_REQUEST)
+                raise ParseError("Items in bulk PATCH must have 'id' attribute")
 
     def list_partial_update(self, request):
         self._validate_list(request)

--- a/rest-api/tests/test_saltkey.py
+++ b/rest-api/tests/test_saltkey.py
@@ -1,0 +1,30 @@
+import mock
+import logging
+
+from django.utils.unittest import TestCase
+from calamari_rest.views.v2 import SaltKeyViewSet, ParseError
+
+log = logging.getLogger(__name__)
+
+
+def fake_list(*args, **kwargs):
+    return [{'id': 'ubuntu',
+             'status': 'pre'}
+            ]
+
+
+class TestSaltKeyValidation(TestCase):
+
+    def setUp(self):
+        self.request = mock.Mock()
+        self.request.method = 'POST'
+
+        with mock.patch('calamari_rest.views.v2.RPCViewSet'):
+            self.viewset = SaltKeyViewSet()
+            self.viewset.client = mock.MagicMock()
+            self.viewset.client.list = fake_list
+            self.viewset.client.get.return_value = fake_list()[0]
+
+    def test_passing_one_to_list_bulk_update_fails_validation(self):
+        self.request.DATA = {'id': 'ubuntu', 'status': 'accepted'}
+        self.assertRaises(ParseError, self.viewset.list_partial_update, self.request)


### PR DESCRIPTION
@jcsp @dmick @yanfali 
minimal fix for http://tracker.ceph.com/issues/8179

There is more I want to do here:
- reorganize the validation to be more consistent.
- add more unit tests
- generalize a TestCase where I do what I am doing in setUp
