### PR TITLE
Implement logging.getChild() with join() (not in 2.6)

### DIFF
--- a/cthulhu/cthulhu/manager/server_monitor.py
+++ b/cthulhu/cthulhu/manager/server_monitor.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import json
 import datetime
 from dateutil import tz
+import logging
 import time
 
 from gevent import greenlet
@@ -36,8 +37,8 @@ TICK_PERIOD = 10
 REBOOT_THRESHOLD = datetime.timedelta(seconds=10)
 
 
-log = cthulhu_log.getChild("server_monitor")
-
+# getChild isn't in 2.6
+log = logging.getLogger('.'.join((cthulhu_log.name, 'server_monitor')))
 
 class GrainsNotFound(Exception):
     pass

--- a/cthulhu/cthulhu/manager/user_request.py
+++ b/cthulhu/cthulhu/manager/user_request.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from salt.client import LocalClient
@@ -51,8 +52,9 @@ class UserRequestBase(object):
         wants a cluster name when you create a client, and otherwise we would
         have to look up via ceph.conf.
         """
-        self.log = log.getChild(self.__class__.__name__)
-
+        # getChild isn't in 2.6
+        logname = '.'.join((log.name, self.__class__.__name__)))
+        self.log = logging.getLogger(logname)
         self.requested_at = now()
         self.completed_at = None
 


### PR DESCRIPTION
Fixes: #8524
Signed-off-by: Dan Mick dan.mick@inktank.com
