### PR TITLE
Fix tests to not alter the default pools

### DIFF
--- a/tests/test_pool_management.py
+++ b/tests/test_pool_management.py
@@ -171,7 +171,7 @@ class TestPoolManagement(RequestTestCase):
         mods = self._non_default_args(cluster_id)
         for var, val in mods.items():
             # Sanity check we really are changing something, that the new val is diff
-            self.assertNotEqual(pool[var], val)
+            self.assertNotEqual(pool[var], val, '%s did not change' % (var))
             try:
                 self._update(cluster_id, pool_id, {var: val})
                 pool = self.api.get("cluster/%s/pool/%s" % (cluster_id, pool_id)).json()

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -45,7 +45,7 @@ class TestApi(ServerTestCase):
         pool_id = response.json()[0]['id']
 
         # Make sure there is at least one request
-        response = self.api.patch("cluster/%s/pool/%s" % (fsid, pool_id), {'name': 'newname'})
+        response = self.api.post("cluster/%s/pool" % (fsid), {'name': 'newname', 'pg_num': 64, 'pgp_num': 64})
         self.assertEqual(response.status_code, 202)
         request_id = response.json()['request_id']
 


### PR DESCRIPTION
Signed-off-by: Gregory Meno gregory.meno@inktank.com

@jcsp Creates a pool instead of updating a pool to generate a request
