### PR TITLE
calamari_web: improve static file serving

### DIFF
--- a/calamari-web/calamari_web/urls.py
+++ b/calamari-web/calamari_web/urls.py
@@ -6,6 +6,7 @@ from settings import STATIC_ROOT, GRAPHITE_API_PREFIX, CONTENT_DIR
 # from django.contrib import admin
 # admin.autodiscover()
 
+
 urlpatterns = patterns(
     '',
 
@@ -19,23 +20,11 @@ urlpatterns = patterns(
     url(r'^api/v1/', include('calamari_rest.urls.v1')),
     url(r'^api/v2/', include('calamari_rest.urls.v2')),
 
-    url(r'^admin/(?P<path>.*)$', 'calamari_web.views.serve_dir_or_index',
-        {'document_root': '%s/admin/' % STATIC_ROOT}),
-
-    url(r'^login/$', 'django.views.static.serve',
-        {'document_root': '%s/login/' % STATIC_ROOT, 'path': "index.html"}),
-
-    url(r'^login/(?P<path>.*)$', 'django.views.static.serve',
-        {'document_root': '%s/login/' % STATIC_ROOT}),
-
     url(r'^bootstrap$', 'calamari_web.views.bootstrap', name='bootstrap'),
 
     url(r'^dashboard/(?P<path>.*)$', 'calamari_web.views.dashboard',
         {'document_root': '%s/dashboard/' % STATIC_ROOT},
         name='dashboard'),
-
-    url(r'^manage/(?P<path>.*)$', 'calamari_web.views.serve_dir_or_index',
-        {'document_root': '%s/manage/' % STATIC_ROOT}),
 
     url(r'^render/?', include('graphite.render.urls')),
     url(r'^metrics/?', include('graphite.metrics.urls')),
@@ -55,6 +44,12 @@ urlpatterns = patterns(
     url(r'^static/el6/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': '%s/el6/' % STATIC_ROOT}),
 )
+
+UI_PATHS = ['login', 'admin', 'manage']
+
+for path in UI_PATHS:
+    urlpatterns = urlpatterns + [url(r'^{0}/(?P<path>.*)$'.format(path), 'calamari_web.views.serve_dir_or_index',
+                                     {'document_root': '{0}/{1}/'.format(STATIC_ROOT, path)})]
 
 handler500 = 'calamari_web.views.server_error'
 

--- a/calamari-web/calamari_web/views.py
+++ b/calamari-web/calamari_web/views.py
@@ -3,7 +3,7 @@
 from django.views.static import serve as static_serve
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect, HttpResponse, \
-    HttpResponseServerError
+    HttpResponseServerError, Http404
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.views.decorators.csrf import requires_csrf_token
@@ -18,11 +18,16 @@ def home(request):
     return HttpResponseRedirect(reverse('dashboard', kwargs={'path': ''}))
 
 
-@login_required
 def serve_dir_or_index(request, path, document_root):
     if len(path) == 0:
         path = 'index.html'
-    return static_serve(request, path, document_root)
+
+    try:
+        return static_serve(request, path, document_root)
+    except Http404:
+        return HttpResponse(
+            "User interface file not found, check that the Calamari user interface is properly installed.",
+            status=404)
 
 
 @login_required


### PR DESCRIPTION
- Remove the login_required on serving static files, the UI
  handles the case where it's loaded without authentication.
- Less repetition in setting up the URLs, just have a list of paths
  to serve (but still with the special case for dashboard :-/)
- Give a helpful message when UI files are not found, to reduce
  the "why is it saying /login/ not found?" queries.

Signed-off-by: John Spray john.spray@redhat.com
