### PR TITLE
Implement logging.getChild() with join() (not in 2.6) in other places

### DIFF
--- a/calamari-common/calamari_common/salt_wrapper.py
+++ b/calamari-common/calamari_common/salt_wrapper.py
@@ -9,6 +9,7 @@ environment.
 
 
 import gevent
+import logging
 
 
 try:
@@ -56,7 +57,8 @@ class SaltEventSource(object):
         """
         :param config: a salt client_config instance
         """
-        self._log = logger.getChild("salt")
+        # getChild isn't in 2.6
+        self._log = logging.getLogger('.'.join((logger.name, 'salt')))
         self._silence_counter = 0
         self._config = config
         self._master_event = MasterEvent(self._config['sock_dir'])

--- a/cthulhu/cthulhu/manager/request_collection.py
+++ b/cthulhu/cthulhu/manager/request_collection.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from gevent.lock import RLock
 import datetime
+import logging
 
 from calamari_common.salt_wrapper import LocalClient
 from cthulhu.gevent_util import nosleep
@@ -12,7 +13,8 @@ from cthulhu.manager import config
 TICK_PERIOD = 20
 
 
-log = cthulhu_log.getChild("request_collection")
+# getChild isn't in 2.6
+log = logging.getLogger('.'.join((cthulhu_log.name, 'request_collection')))
 
 
 class RequestCollection(object):


### PR DESCRIPTION
the patch is like 685a57ed762a9a6e7aea420a6189c3651b03f018
