### PR TITLE
Fix socket path pattern match

### DIFF
--- a/salt/srv/salt/_modules/ceph.py
+++ b/salt/srv/salt/_modules/ceph.py
@@ -469,7 +469,7 @@ def service_status(socket_path):
     """
     Given an admin socket path, learn all we can about that service
     """
-    cluster_name, service_type, service_id = re.match("^(.*)-(.*)\.(.*).asok$", os.path.basename(socket_path)).groups()
+    cluster_name, service_type, service_id = re.match("^(.+)-(mon|osd|mds)\.(.+)\.asok$", os.path.basename(socket_path)).groups()
     # Interrogate the service for its FSID
     config = json.loads(admin_socket(socket_path, ['config', 'get', 'fsid'], 'json'))
     fsid = config['fsid']


### PR DESCRIPTION
The old regular expression for socket path can't catch the example
"ceph-mon.www-2.abc.com.asok", if we use the old regular expression, the
cluster_name,service_type,service_id will be incorrect.
The new regular expression  "^(.+)-(mon|osd|mds).(.+).asok$" can catch the
example and I think  "(mon|osd|mds)" will match all service type in ceph.
