### PR TITLE
pycairo is a dependency of graphite-web (masked by extra packages on vps...

### DIFF
--- a/calamari.spec
+++ b/calamari.spec
@@ -17,6 +17,7 @@ BuildRequires:  postgresql-libs
 Requires:       httpd
 Requires:	mod_wsgi
 Requires:       cairo
+Requires:       pycairo
 Requires:	logrotate
 Requires:       supervisor
 Requires:       salt-master


### PR DESCRIPTION
...es)

Fixes: #8723
Signed-off-by: Dan Mick dan.mick@inktank.com
