### PR TITLE
build: Added support for Ubuntu Trusty 64bit build configuration.

### DIFF
--- a/vagrant/trusty-build/Vagrantfile
+++ b/vagrant/trusty-build/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "trusty64"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//git", "1"]
+  end
+
+  config.vm.synced_folder "../../../", "/git"
+  config.vm.synced_folder "salt/roots/", "/srv/salt/"
+  config.vm.provision :salt do |salt|
+    salt.minion_config = "salt/minion"
+    salt.verbose = true
+    salt.run_highstate = true
+  end
+end

--- a/vagrant/trusty-build/salt/minion
+++ b/vagrant/trusty-build/salt/minion
@@ -1,0 +1,2 @@
+master: localhost
+file_client: local

--- a/vagrant/trusty-build/salt/roots/build_deps.sls
+++ b/vagrant/trusty-build/salt/roots/build_deps.sls
@@ -1,0 +1,39 @@
+install_salt:
+    pkgrepo.managed:
+    - humanname: salt PPA
+    - name: deb http://ppa.launchpad.net/saltstack/salt/ubuntu trusty main
+    - dist: trusty
+    - file: /etc/apt/sources.list.d/saltstack.list
+    - keyid: 0E27C0A6
+    - keyserver: keyserver.ubuntu.com
+    pkg.latest:
+    - name: salt-master
+    - refresh: True
+
+build_deps:
+  pkg.installed:
+    - pkgs:
+      - build-essential
+      - python-virtualenv
+      - git
+      - python-dev
+      - swig
+      - libzmq-dev
+      - g++
+      - python-cairo
+      - make
+      - devscripts
+      - libpq-dev
+      - cython
+      - debhelper
+      - python-mock
+      - python-configobj
+      - cdbs
+      - python-sphinx
+      - libcairo2-dev
+      - python-m2crypto
+      - python-crypto
+      - reprepro
+      - python-support
+
+

--- a/vagrant/trusty-build/salt/roots/git_clone.sls
+++ b/vagrant/trusty-build/salt/roots/git_clone.sls
@@ -1,0 +1,26 @@
+calamari_clone:
+  git:
+    - latest
+    - user: vagrant
+    - target: /home/vagrant/calamari
+    - name: /git/calamari
+    - require:
+      - pkg: build_deps
+
+diamond_clone:
+  git:
+    - latest
+    - user: vagrant
+    - target: /home/vagrant/Diamond
+    - name: /git/Diamond
+    - require:
+      - pkg: build_deps
+
+#salt_clone:
+#  git:
+#    - latest
+#    - user: vagrant
+#    - target: /home/vagrant/calamari-salt
+#    - name: /git/calamari-salt
+#    - require:
+#      - pkg: build_deps

--- a/vagrant/trusty-build/salt/roots/make_packages.sls
+++ b/vagrant/trusty-build/salt/roots/make_packages.sls
@@ -1,0 +1,35 @@
+build-diamond:
+  cmd.run:
+    - user: vagrant
+    - name: make deb
+    - cwd: /home/vagrant/Diamond
+    - require:
+      - git: /git/Diamond
+
+build-repo:
+  cmd.run:
+    - user: vagrant
+    - name: make ubuntu
+    - cwd: /home/vagrant/calamari/repobuild
+    - require:
+      - git: /git/calamari
+      - cmd: build-diamond
+
+build-calamari-server:
+  cmd.run:
+    - user: vagrant
+    - name: make dpkg
+    - cwd: /home/vagrant/calamari
+    - require:
+      - git: /git/calamari
+
+{% for path in ('calamari/repobuild/calamari-repo-ubuntu.tar.gz',
+                'calamari-server_*.deb',
+                'Diamond/build/diamond_*.deb') %}
+
+cp-artifacts-to-share {{ path }}:
+  cmd.run:
+    - name: cp {{ path }} /git/
+    - cwd: /home/vagrant/
+
+{% endfor %}

--- a/vagrant/trusty-build/salt/roots/top.sls
+++ b/vagrant/trusty-build/salt/roots/top.sls
@@ -1,0 +1,5 @@
+base:
+  '*':
+      - build_deps
+      - git_clone
+      - make_packages


### PR DESCRIPTION
Scripts for building on Ubuntu Trusty 64bit added.
Added the package python-support for trusty64.
Compiling on trusty64 ran out of memory with the default Vagrant configuration. Adjusted RAM from 512MB to 1024MB.

Signed-off-by: Jason Brown jebrown@masterforge.com
