### PR TITLE
calamari_rest: handle serverless service

### DIFF
--- a/rest-api/calamari_rest/views/v1.py
+++ b/rest-api/calamari_rest/views/v1.py
@@ -373,7 +373,10 @@ class OSDList(RPCView):
         # Apply the ServerMonitor data
         for o, (service_id, fqdn) in zip(osds, service_to_server):
             o['fqdn'] = fqdn
-            o['host'] = fqdn_to_server[fqdn]['hostname']
+            if fqdn is not None:
+                o['host'] = fqdn_to_server[fqdn]['hostname']
+            else:
+                o['host'] = None
 
         return osds, osds_by_pg_state
 


### PR DESCRIPTION
This case can happen during removal of servers, where
any service using that server will be unhooked from it
by setting the service's server to None.

Signed-off-by: John Spray john.spray@redhat.com
