### PR TITLE
urllib-bootstrap-salt.sh: Add flexibility/diagnosability

### DIFF
--- a/vagrant/urllib-bootstrap-salt.sh
+++ b/vagrant/urllib-bootstrap-salt.sh
@@ -1,8 +1,10 @@
 #!/bin/sh -
 
 # just use urllib; tired of curl failing mid-bootstrap.  urllib always works.
+# Save a copy of the downloaded script.
 
-python \
-    -c 'import urllib; print urllib.urlopen("https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh").read()' \
-    | sh -s -- "$@"
+URL=https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
+
+python -c 'import urllib; print urllib.urlopen("'${URL}'").read()' \
+    | tee /tmp/salt-bootstrap-script | sh -s -- "$@"
 


### PR DESCRIPTION
Allow easy setting of URL, and keep a copy of the downloaded script
in case things go wrong
