### PR TITLE
calamari python pkg setup.py: zip_safe=False to install unzipped eggs

### DIFF
--- a/calamari-common/setup.py
+++ b/calamari-common/setup.py
@@ -8,6 +8,7 @@ setup(
     author="Inktank Storage Inc.",
     author_email="info@inktank.com",
     license="LGPL-2.1+",
+    zip_safe=False,
     entry_points={
         'console_scripts': [
         ]

--- a/calamari-web/setup.py
+++ b/calamari-web/setup.py
@@ -8,5 +8,6 @@ setup(
     url="http://www.inktank.com/enterprise/",
     author="Inktank Storage Inc.",
     author_email="info@inktank.com",
-    license="LGPL-2.1+"
+    license="LGPL-2.1+",
+    zip_safe=False,
 )

--- a/cthulhu/setup.py
+++ b/cthulhu/setup.py
@@ -8,6 +8,7 @@ setup(
     author="Inktank Storage Inc.",
     author_email="info@inktank.com",
     license="LGPL-2.1+",
+    zip_safe=False,
     entry_points={
         'console_scripts': [
             'cthulhu-manager = cthulhu.manager.manager:main',

--- a/minion-sim/setup.py
+++ b/minion-sim/setup.py
@@ -8,6 +8,7 @@ setup(
     author="Inktank Storage Inc.",
     author_email="info@inktank.com",
     license="LGPL-2.1+",
+    zip_safe=False,
     entry_points={
         'console_scripts': [
             'minion-sim = minion_sim.sim:main',

--- a/rest-api/setup.py
+++ b/rest-api/setup.py
@@ -8,5 +8,6 @@ setup(
     url="http://www.inktank.com/enterprise/",
     author="Inktank Storage Inc.",
     author_email="info@inktank.com",
-    license="LGPL-2.1+"
+    license="LGPL-2.1+",
+    zip_safe=False,
 )


### PR DESCRIPTION
Zipped eggs are harder to patch/deal with when installed; it's handier
if they're unpacked when installed on the server.

Signed-off-by: Dan Mick dan.mick@inktank.com
