### PR TITLE
calamari-ctl: relax perms on some salt dirs during initialization

### DIFF
--- a/salt/local/relax_salt_perms.sls
+++ b/salt/local/relax_salt_perms.sls
@@ -1,0 +1,7 @@
+# http://docs.saltstack.com/en/latest/ref/clientacl.html#permission-issues
+# work around for https://github.com/saltstack/salt/issues/14768
+
+allow_master_pillar_util_access:
+    cmd.run:
+        - name: chmod 0755 /var/cache/salt /var/cache/salt/master /var/cache/salt/jobs /var/run/salt
+        - user: root


### PR DESCRIPTION
Fixes: #8743
Signed-off-by: Gregory Meno gmeno@redhat.com

@dmick @jcsp 
I could not seem to get the log_tail stuff working in time for this. I plan to leave it as is and tackle it in the next sprint.
