### PR TITLE
Fix make targets in make_packages

### DIFF
--- a/vagrant/precise-build/salt/roots/make_packages.sls
+++ b/vagrant/precise-build/salt/roots/make_packages.sls
@@ -9,7 +9,7 @@ build-diamond:
 build-repo:
   cmd.run:
     - user: vagrant
-    - name: make ubuntu
+    - name: make precise
     - cwd: /home/vagrant/calamari/repobuild
     - require:
       - git: /git/calamari

--- a/vagrant/trusty-build/salt/roots/make_packages.sls
+++ b/vagrant/trusty-build/salt/roots/make_packages.sls
@@ -9,7 +9,7 @@ build-diamond:
 build-repo:
   cmd.run:
     - user: vagrant
-    - name: make ubuntu
+    - name: make trusty
     - cwd: /home/vagrant/calamari/repobuild
     - require:
       - git: /git/calamari


### PR DESCRIPTION
The ubuntu target no longer exists. Each build now has a separate target in the Makefile.
