### PR TITLE
calamari_ctl.py: move get_user_model import to initialize function

### DIFF
--- a/cthulhu/cthulhu/calamari_ctl.py
+++ b/cthulhu/cthulhu/calamari_ctl.py
@@ -13,7 +13,6 @@ import subprocess
 from django.core.management import execute_from_command_line
 import pwd
 from django.utils.crypto import get_random_string
-from django.contrib.auth import get_user_model
 import time
 from calamari_common.config import CalamariConfig, AlembicConfig
 from sqlalchemy import create_engine
@@ -121,6 +120,8 @@ def initialize(args):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "calamari_web.settings")
     with quiet():
         execute_from_command_line(["", "syncdb", "--noinput"])
+
+    from django.contrib.auth import get_user_model
 
     log.info("Initializing web interface...")
     user_model = get_user_model()


### PR DESCRIPTION
Having 'from django.contrib.auth import get_user_model' at the top of
the file causes an exception with Django 1.6 on openSUSE, due to
DJANGO_SETTINGS_MODULE not being set yet.  Moving the import to the
initialize function fixes this (although it violates PEP-8).

Signed-off-by: Tim Serong tserong@suse.com
