### PR TITLE
tests: cope better with `ceph pg stat` output

### DIFF
--- a/tests/ceph_ctl.py
+++ b/tests/ceph_ctl.py
@@ -248,7 +248,7 @@ class ExternalCephControl(CephControl):
                                      cluster=self.cluster_name))
 
     def _check_pgs_active_and_clean(self, output):
-        _, total_stat, pg_stat, _ = output.replace(';', ':').split(':')
+        total_stat, pg_stat = output.replace(';', ':').split(':')[1:3]
         return 'active+clean' == pg_stat.split()[1] and total_stat.split()[0] == pg_stat.split()[0]
 
     def _list_osds(self):


### PR DESCRIPTION
Most of the time, `ceph pg stat` gives output like:

"v211: 192 pgs: 192 active+clean; 16 bytes data, 232 MB used, 11154 GB /
11154 GB avail"

The current code splits on ':' and ';', and expects this to result in
four parts.  Occasionally though, `ceph pg stat` has some extra
information about recovery, which gives five parts:

"v136: 192 pgs: 192 active+clean; 16 bytes data, 239 MB used, 11154 GB /
11154 GB avail; 5 B/s, 0 objects/s recovering"

The way the splitting and assignment was implemented, the second output
would raise ValueError: too many values to unpack.  This change slices
the split to only grab total_stat and pg_stat, which is what we actually
care about.

Signed-off-by: Tim Serong tserong@suse.com
