### PR TITLE
Missed a few 'ubuntu -> precise/trusty' changes

### DIFF
--- a/calamari-web/calamari_web/urls.py
+++ b/calamari-web/calamari_web/urls.py
@@ -39,10 +39,18 @@ urlpatterns = patterns(
     url('^content/(?P<path>.*)$', 'django.views.static.serve', {'document_root': CONTENT_DIR}),
 
     # XXX this is a hack to serve apt repo in dev mode (Full installation serves this with apache)
-    url(r'^static/ubuntu/(?P<path>.*)$', 'django.views.static.serve',
-        {'document_root': '%s/ubuntu/' % STATIC_ROOT}),
+    url(r'^static/precise/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': '%s/precise/' % STATIC_ROOT}),
+    url(r'^static/trusty/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': '%s/trusty/' % STATIC_ROOT}),
+    url(r'^static/wheezy/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': '%s/wheezy/' % STATIC_ROOT}),
     url(r'^static/el6/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': '%s/el6/' % STATIC_ROOT}),
+    url(r'^static/rhel6/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': '%s/rhel6/' % STATIC_ROOT}),
+    url(r'^static/rhel7/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': '%s/rhel7/' % STATIC_ROOT}),
 )
 
 UI_PATHS = ['login', 'admin', 'manage']

--- a/get-flavor.sh
+++ b/get-flavor.sh
@@ -7,7 +7,7 @@ VERSION=$(lsb_release -r -s)
 # ID is:
 # Centos6.4: CentOS
 # RHEL6: RedHatEnterpriseServer
-# precise: Ubuntu
+# precise, trusty: Ubuntu
 # wheezy: Debian
 # SLES: SUSE Linux
 # openSUSE: openSUSE project

--- a/repobuild/Makefile
+++ b/repobuild/Makefile
@@ -1,7 +1,7 @@
 precise:
 	reprepro --confdir=./conf/precise --noskipold -b ./precise/ update
 	# Using plain salt-minion for the moment (#6855)
-	#       reprepro -b ubuntu/ includedeb precise ../../calamari-salt-minion_*.deb
+	#       reprepro -b precise/ includedeb precise ../../calamari-salt-minion_*.deb
 	reprepro --confdir=./conf/precise -b ./precise/ remove precise diamond
 	reprepro --confdir=./conf/precise --noskipold -b ./precise/ includedeb precise ../../Diamond/build/*.deb
 	tar czf calamari-repo-precise.tar.gz precise/
@@ -9,15 +9,15 @@ precise:
 trusty:
 	reprepro --confdir=./conf/trusty --noskipold -b ./trusty/ update
 	# Using plain salt-minion for the moment (#6855)
-	#       reprepro -b ubuntu/ includedeb precise ../../calamari-salt-minion_*.deb
+	#       reprepro -b trusty/ includedeb precise ../../calamari-salt-minion_*.deb
 	reprepro --confdir=./conf/trusty -b ./trusty/ remove trusty diamond
-	reprepro --confdir=./conf/trusty --noskipold -b ./ubuntu/ includedeb trusty ../../Diamond/build/*.deb
+	reprepro --confdir=./conf/trusty --noskipold -b ./trusty/ includedeb trusty ../../Diamond/build/*.deb
 	tar czf calamari-repo-trusty.tar.gz trusty/
 
 wheezy:
 	reprepro --confdir=./conf/wheezy --noskipold -b ./wheezy/ update
 	# Using plain salt-minion for the moment (#6855)
-	#       reprepro -b ubuntu/ includedeb precise ../../calamari-salt-minion_*.deb
+	#       reprepro -b wheezy/ includedeb precise ../../calamari-salt-minion_*.deb
 	reprepro --confdir=./conf/wheezy -b ./wheezy/ remove wheezy diamond
 	reprepro --confdir=./conf/wheezy --noskipold -b ./wheezy/ includedeb wheezy ../../Diamond/build/*.deb
 	tar czf calamari-repo-wheezy.tar.gz wheezy/
@@ -49,6 +49,6 @@ rhel7:
 	tar czf calamari-repo-rhel7.tar.gz rhel7/
 
 clean:
-	rm -rf el6 rhel6 rhel7 ubuntu wheezy
+	rm -rf el6 rhel6 rhel7 precise trusty wheezy
 
 .PHONY: precise trusty wheezy el6 rhel6 rhel7 clean

--- a/vagrant/precise-build/salt/roots/make_packages.sls
+++ b/vagrant/precise-build/salt/roots/make_packages.sls
@@ -9,7 +9,7 @@ build-diamond:
 build-repo:
   cmd.run:
     - user: vagrant
-    - name: make ubuntu
+    - name: make precise
     - cwd: /home/vagrant/calamari/repobuild
     - require:
       - git: /git/calamari
@@ -23,7 +23,7 @@ build-calamari-server:
     - require:
       - git: /git/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-ubuntu.tar.gz',
+{% for path in ('calamari/repobuild/calamari-repo-precise.tar.gz',
                 'calamari-server_*.deb',
                 'Diamond/build/diamond_*.deb') %}
 

--- a/vagrant/trusty-build/salt/roots/make_packages.sls
+++ b/vagrant/trusty-build/salt/roots/make_packages.sls
@@ -9,7 +9,7 @@ build-diamond:
 build-repo:
   cmd.run:
     - user: vagrant
-    - name: make ubuntu
+    - name: make trusty
     - cwd: /home/vagrant/calamari/repobuild
     - require:
       - git: /git/calamari
@@ -23,7 +23,7 @@ build-calamari-server:
     - require:
       - git: /git/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-ubuntu.tar.gz',
+{% for path in ('calamari/repobuild/calamari-repo-trusty.tar.gz',
                 'calamari-server_*.deb',
                 'Diamond/build/diamond_*.deb') %}
 


### PR DESCRIPTION
428ad273332a647b404a6c340c58880a72e0c898 added trusty builds, and
changed several 'ubuntu' names to either 'precise' or 'trusty';
there were several things connected with the local minion repo that
did not get fixed (the bootstrap script, the salt states for
making the repos, etc.)  This commit is the result of a scan for
'ubuntu' in any case and a replacement/fix for the missing bits.

Signed-off-by: Dan Mick dan.mick@inktank.com
