### PR TITLE
Set VirtualHost ServerName to 'calamari'

### DIFF
--- a/conf/httpd/calamari.conf
+++ b/conf/httpd/calamari.conf
@@ -3,7 +3,7 @@
 </IfModule>
 
 <VirtualHost *:80>
-    ServerName graphite
+    ServerName calamari
     DocumentRoot "/opt/calamari/webapp"
     ErrorLog /var/log/calamari/httpd_error.log
     CustomLog /var/log/calamari/httpd_access.log common


### PR DESCRIPTION
Prior to commit 525606f, the debian calamari.conf had ServerName set to
'graphite', while the el6 and rhel7 calamari.conf files had it set to
'calamari'.  I'm assuming 'calamari' is preferable to 'graphite' in this
context ;)

Signed-off-by: Tim Serong tserong@suse.com
