### PR TITLE
WIP rest-api: add crush_node_ancestry field to OsdViewSet

### DIFF
--- a/rest-api/calamari_rest/serializers/v2.py
+++ b/rest-api/calamari_rest/serializers/v2.py
@@ -115,7 +115,7 @@ class PoolSerializer(ValidatingSerializer):
 
 class OsdSerializer(ValidatingSerializer):
     class Meta:
-        fields = ('uuid', 'up', 'in', 'id', 'reweight', 'server', 'pools', 'valid_commands', 'public_addr', 'cluster_addr')
+        fields = ('uuid', 'up', 'in', 'id', 'reweight', 'server', 'pools', 'valid_commands', 'public_addr', 'cluster_addr', 'crush_node_ancestry')
         create_allowed = ()
         create_required = ()
         modify_allowed = ('up', 'in', 'reweight')
@@ -132,6 +132,7 @@ class OsdSerializer(ValidatingSerializer):
 
     public_addr = serializers.CharField(read_only=True, help_text="Public/frontend IP address")
     cluster_addr = serializers.CharField(read_only=True, help_text="Cluster/backend IP address")
+    crush_node_ancestry = serializers.Field(help_text="An ordered list of CRUSH node ids that represent a path from the parent node of this OSD up to the root of the tree")
 
 # Declarative metaclass definitions are great until you want
 # to use a reserved word

--- a/rest-api/calamari_rest/views/crush_node.py
+++ b/rest-api/calamari_rest/views/crush_node.py
@@ -1,0 +1,20 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def lookup_ancestry(osd_id, parent_map):
+    log.info('lookup' + str(parent_map))
+    ancestries = []
+    for parent in parent_map.get(osd_id, []):
+        parent_id = parent.get('id')
+        ancestry = [parent_id]
+        while(parent and parent_id is not None):
+            parent = parent_map.get(parent_id, [])
+            if parent:
+                parent_id = parent[0].get('id')
+                if parent_id is not None:
+                    ancestry.append(parent_id)
+        ancestries.append(ancestry)
+
+    return ancestries

--- a/rest-api/tests/test_crush_node_ancestry.py
+++ b/rest-api/tests/test_crush_node_ancestry.py
@@ -1,0 +1,55 @@
+import logging
+
+from unittest import TestCase
+from calamari_rest.views.crush_node import lookup_ancestry
+
+log = logging.getLogger(__name__)
+
+
+class TestCrushNodeAncestry(TestCase):
+
+    def setUp(self):
+        pass
+
+    def testNone(self):
+        osd_id = 0
+        fake_parent_map = {}
+        self.assertEqual([], lookup_ancestry(osd_id, fake_parent_map))
+
+    def testOne(self):
+        osd_id = 0
+        fake_parent_map = {0: [{'id': -1}]}
+        self.assertEqual([[-1]], lookup_ancestry(osd_id, fake_parent_map))
+
+    def testSome(self):
+        osd_id = 0
+        fake_parent_map = dict([(x, [{'id': x + 1}]) for x in range(-5, -1)])
+        fake_parent_map[osd_id] = [{'id': -5}]
+        self.assertEqual([[-5, -4, -3, -2, -1]], lookup_ancestry(osd_id, fake_parent_map))
+
+    def test_many(self):
+        osd_id = 0
+        # This is unrealistic no CRUSH tree should ever be this deep
+        depth = -50000
+        fake_parent_map = dict([(x, [{'id': x + 1}]) for x in range(depth, -1)])
+        fake_parent_map[osd_id] = [{'id': depth}]
+        self.assertEqual([range(depth, 0)], lookup_ancestry(osd_id, fake_parent_map))
+
+    def test_some_multiple_osd_mapping(self):
+        osd_id = 0
+        fake_parent_map = {0: [{'id': -1}, {'id': -2}], -1: [{'id': -3}], -2: [{'id': -3}]}
+        self.assertEqual([[-1, -3], [-2, -3]], lookup_ancestry(osd_id, fake_parent_map))
+
+    def test_strange_map(self):
+        osd_id = 1
+        fake_parent_map = {-5: [{'id': -10, }],
+                           -4: [{'id': -5, },
+                                {'id': -1}],
+                           -3: [{'id': -5, },
+                                {'id': -1}],
+                           -2: [{'id': -5, },
+                                {'id': -1}],
+                           1: [{'id': -20, },
+                               {'id': -2}]}
+
+        self.assertEqual([[-20], [-2, -5, -10]], lookup_ancestry(osd_id, fake_parent_map))


### PR DESCRIPTION
Signed-off-by: Gregory Meno gregory.meno@inktank.com

@jcsp @dmick This is half of the work for #8666 getting it out early since I will be folowing the same pattern to add to hosts. Should I add to ServerViewSet or ServerClusterViewSet or both?
