### PR TITLE
Add dependency `python-setuptools`

### DIFF
--- a/calamari.spec
+++ b/calamari.spec
@@ -26,6 +26,7 @@ Requires:       redhat-lsb-core
 Requires:	postgresql
 Requires:	postgresql-libs
 Requires:	postgresql-server
+Requires:	python-setuptools
 Version: 	%{version}
 Release: 	%{?revision}%{?dist}
 License: 	LGPL-2.1+


### PR DESCRIPTION
If setuptools is not installed, cthulhu cannot be started:

```
# supervisorctl restart cthulhu
Traceback (most recent call last):
  File "/usr/bin/supervisorctl", line 5, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
```
