### PR TITLE
rest-api: change name validation on update and tests for same

### DIFF
--- a/rest-api/calamari_rest/views/v2.py
+++ b/rest-api/calamari_rest/views/v2.py
@@ -463,7 +463,7 @@ but those without static defaults will be set to null.
 
     def _validate_semantics(self, fsid, pool_id, data):
         errors = defaultdict(list)
-        self._check_name_unique(fsid, data, errors)
+        self._check_name_unique(fsid, pool_id, data, errors)
         self._check_crush_ruleset(fsid, data, errors)
         self._check_pgp_less_than_pg_num(data, errors)
         self._check_pg_nums_dont_decrease(fsid, pool_id, data, errors)
@@ -501,8 +501,9 @@ but those without static defaults will be set to null.
         if 'pgp_num' in data and 'pg_num' in data and data['pg_num'] < data['pgp_num']:
             errors['pgp_num'].append('must be >= to pg_num')
 
-    def _check_name_unique(self, fsid, data, errors):
-        if 'name' in data and data['name'] in [x.pool_name for x in [PoolDataObject(p) for p in self.client.list(fsid, POOL, {})]]:
+    def _check_name_unique(self, fsid, pool_id, data, errors):
+        pool_name_to_id = dict([(x.pool_name, x.pool) for x in [PoolDataObject(p) for p in self.client.list(fsid, POOL, {})]])
+        if pool_name_to_id.get(data.get('name')) not in (None, pool_id):
             errors['name'].append('Pool with name {name} already exists'.format(name=data['name']))
 
 

--- a/rest-api/tests/test_pool.py
+++ b/rest-api/tests/test_pool.py
@@ -16,6 +16,12 @@ def fake_list(fsid, type, filter, **kwargs):
                  'pg_num': 64,
                  'type': 1,
                  'pool': 0,
+                 'size': 2},
+                {'pool_name': 'notdata',
+                 'pg_placement_num': 64,
+                 'pg_num': 64,
+                 'type': 1,
+                 'pool': 1,
                  'size': 2}
                 ]
     elif type == CRUSH_RULE:
@@ -96,8 +102,14 @@ class TestPoolValidation(TestCase):
     def test_update_name_duplication_fails(self):
         self.request.method = 'PATCH'
         self.request.DATA = {'name': 'data', 'pg_num': 64}
-        response = self.pvs.update(self.request, 12345, 0)
+        response = self.pvs.update(self.request, 12345, 1)
         self.assertEqual(response.status_code, 409)
+
+    def test_update_name_not_duplicate_on_same_pool(self):
+        self.request.method = 'PATCH'
+        self.request.DATA = {'name': 'data', 'pg_num': 64}
+        response = self.pvs.update(self.request, 12345, 0)
+        self.assertEqual(response.status_code, 202)
 
     def test_update_without_name_works(self):
         self.request.method = 'PATCH'


### PR DESCRIPTION
This allows name to be present on an update, and still rejects updating
a pool to have the same name as another pool

Signed-off-by: Gregory Meno gmeno@redhat.com

@dmick @jcsp 
