### PR TITLE
Allow admin user to be renamed, and noninteractive password changes

### DIFF
--- a/cthulhu/cthulhu/calamari_ctl.py
+++ b/cthulhu/cthulhu/calamari_ctl.py
@@ -182,12 +182,13 @@ def change_password(args):
     else:
         execute_from_command_line(["", "changepassword", args.username])
 
+
 def rename_user(args):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "calamari_web.settings")
     from django.contrib.auth import get_user_model
     user_model = get_user_model()
     try:
-        new_user = user_model.objects.get(username=args.new_username)
+        user_model.objects.get(username=args.new_username)
         log.error("New username '%s' is already in use." % args.new_username)
     except user_model.DoesNotExist:
         try:
@@ -196,6 +197,7 @@ def rename_user(args):
             user.save()
         except user_model.DoesNotExist:
             log.error("User '%s' does not exist." % args.username)
+
 
 def clear(args):
     if not args.yes_i_am_sure:


### PR DESCRIPTION
These two commits allow the admin user to be renamed, and allow a user's password to be set via command line argument (i.e. noninteractively). These changes both help if you're using a deployment automation tool (e.g.: Chef) to deploy Calamari, and have parameterized the admin username and password in that tool.
