### PR TITLE
cthulhu: stop comparing osd data from the previous map in _on_osd_map

### DIFF
--- a/cthulhu/cthulhu/manager/eventer.py
+++ b/cthulhu/cthulhu/manager/eventer.py
@@ -245,7 +245,7 @@ class Eventer(gevent.greenlet.Greenlet):
 
     def _on_osd_map(self, fsid, new, old):
         old_osd_ids = set([o['osd'] for o in old.data['osds']])
-        new_osd_ids = set([o['osd'] for o in old.data['osds']])
+        new_osd_ids = set([o['osd'] for o in new.data['osds']])
         deleted_osds = old_osd_ids - new_osd_ids
         created_osds = new_osd_ids - old_osd_ids
 

--- a/cthulhu/tests/test_eventer.py
+++ b/cthulhu/tests/test_eventer.py
@@ -1,0 +1,35 @@
+from django.utils.unittest import TestCase
+from cthulhu.manager.eventer import Eventer
+from django.utils.unittest.case import skipIf
+import os
+from mock import MagicMock
+
+
+class TestEventer(TestCase):
+    def setUp(self):
+        self.eventer = Eventer(MagicMock())
+
+    def tearDown(self):
+        pass
+
+    @skipIf(os.environ.get('CALAMARI_CONFIG') is None, "needs CALAMARI_CONFIG set")
+    def testCreateManager(self):
+        assert self.eventer is not None
+
+    def test_that_it_emits_deleted_osd_events(self):
+        self.eventer._emit = MagicMock()
+        new = MagicMock()
+        old = MagicMock()
+        old.data = {}
+        old.data['osds'] = [{'osd': 0}]
+        self.eventer._on_osd_map(12345, new, old)
+        self.assertIn('removed from the cluster map', '\n'.join([str(x) for x in self.eventer._emit.call_args_list]))
+
+    def test_that_it_emits_added_osd_events(self):
+        self.eventer._emit = MagicMock()
+        new = MagicMock()
+        old = MagicMock()
+        new.data = {}
+        new.data['osds'] = [{'osd': 0}]
+        self.eventer._on_osd_map(12345, new, old)
+        self.assertIn('added to the cluster map', '\n'.join([str(x) for x in self.eventer._emit.call_args_list]))


### PR DESCRIPTION
@dmick @jcsp

We are looking for differences in osd_maps old vs. new and by mistake
the old version was compared to itself to determine if osds were added
or removed so there would never be events for those

Adds tests
Fixes: #10444

Signed-off-by: Gregory Meno <gmeno@redhat.com>