### PR TITLE
build: make version reflect tags and branches

### DIFF
--- a/get-versions.sh
+++ b/get-versions.sh
@@ -12,7 +12,7 @@ RPM='n'
 if [ "$1" == "-r" ] ; then RPM='y' ; shift ; fi
 
 # GITVER is the version from the current git branch, less the first char ('v')
-GITVER=$(git describe | cut -c 2-)
+GITVER=$(git describe --all | sed 's/heads\///;s/^v\([0-9].*$\)/\1/')
 
 # if GITVER contains a '-', separate at the first one into version and revision
 if [[ $GITVER == *-* ]]; then


### PR DESCRIPTION
@dmick 

If you build a package of a yet to be released branch
now the package gets named calamari-server-1.3...
where before it would be called by the nearest tag e.g
calamari-server-1.2.1

Signed-off-by: Gregory Meno <gregory.meno@inktank.com>