### PR TITLE
cthulhu: fix parent_bucket_by_node_id return to be serializable

### DIFF
--- a/calamari-common/calamari_common/types.py
+++ b/calamari-common/calamari_common/types.py
@@ -94,7 +94,7 @@ class OsdMap(VersionedSyncObject):
                         parent_map[child_id].append(node)
                         has_been_mapped.add((child_id, node['id']))
         log.info('crush node parent map {p} version {v}'.format(p=parent_map, v=self.version))
-        return parent_map
+        return dict(parent_map)
 
     @property
     @memoize


### PR DESCRIPTION
@dmick 

This info gets sent across in a messagepack and hence needs to be
able to be serialized which a defaultdict cannot.

Fixes: #10446
Signed-off-by: Gregory Meno <gmeno@redhat.com>