### PR TITLE
Parameterize salt

### DIFF
--- a/vagrant/centos-build/Vagrantfile
+++ b/vagrant/centos-build/Vagrantfile
@@ -10,11 +10,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "centos6"
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 512
+    v.memory = 1024
   end
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "512"]
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//git", "1"]
   end
 

--- a/vagrant/centos-build/salt/roots/build_deps.sls
+++ b/vagrant/centos-build/salt/roots/build_deps.sls
@@ -1,13 +1,3 @@
-install_salt:
-    pkgrepo.managed:
-    - humanname: EPEL
-    - mirrorlist: http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
-    - gpgcheck: 1
-    - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
-    pkg.latest:
-    - name: salt-master
-    - refresh: True
-
 build_deps:
   pkg.installed:
     - pkgs:

--- a/vagrant/centos-build/salt/roots/git_clone.sls
+++ b/vagrant/centos-build/salt/roots/git_clone.sls
@@ -1,18 +1,19 @@
+{% import 'setvars' as vars %}
+
 calamari_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/calamari
-    - name: /git/calamari
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/calamari
+    - name: {{vars.gitpath}}/calamari
     - require:
       - pkg: build_deps
 
 diamond_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/Diamond
-    - name: /git/Diamond
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/Diamond
+    - name: {{vars.gitpath}}/Diamond
     - require:
       - pkg: build_deps
-

--- a/vagrant/centos-build/salt/roots/make_packages.sls
+++ b/vagrant/centos-build/salt/roots/make_packages.sls
@@ -1,35 +1,37 @@
+{% import 'setvars' as vars %}
+
 build-diamond:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make rpm
-    - cwd: /home/vagrant/Diamond
+    - cwd: {{vars.builddir}}/Diamond
     - require:
-      - git: /git/Diamond
+      - git: {{vars.gitpath}}/Diamond
 
 build-repo:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make el6
-    - cwd: /home/vagrant/calamari/repobuild
+    - cwd: {{vars.builddir}}/calamari/repobuild
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
       - cmd: build-diamond
 
 build-calamari-server:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: ./build-rpm.sh
-    - cwd: /home/vagrant/calamari
+    - cwd: {{vars.builddir}}/calamari
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-el6.tar.gz',
-                'rpmbuild/RPMS/x86_64/calamari-server-*.rpm',
-                'Diamond/dist/diamond-*.noarch.rpm') %}
+{% for path in ('calamari/repobuild/calamari-repo-*.tar.gz',
+                'rpmbuild/RPMS/*/calamari-server-*.rpm',
+                'Diamond/dist/diamond-*.rpm') %}
 
-cp-artifacts-to-share {{ path }}:
+cp-artifacts-up {{ path }}:
   cmd.run:
-    - name: cp {{ path }} /git/
-    - cwd: /home/vagrant/
+    - name: cp {{ path }} {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
 
 {% endfor %}

--- a/vagrant/centos-build/salt/roots/setvars
+++ b/vagrant/centos-build/salt/roots/setvars
@@ -1,0 +1,16 @@
+{% set username = salt['environ.get']('SUDO_USER', 'vagrant') %}
+
+{% if username == 'vagrant' %}
+
+{%    set gitpath = '/git' %}
+{%    set builddir = '/home/vagrant' %}
+{%    set pkgdest = gitpath %}
+
+{% else %}
+
+{%    set gitpath = 'git://github.com/ceph' %}
+{%    set builddir = salt['environ.get']('WORKSPACE', salt['user.info'](username)['home']) %}
+{%    set pkgdest = builddir %}
+
+{% endif %}
+

--- a/vagrant/precise-build/Vagrantfile
+++ b/vagrant/precise-build/Vagrantfile
@@ -8,11 +8,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "precise64"
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 512
+    v.memory = 1024
   end
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "512"]
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//git", "1"]
   end
 

--- a/vagrant/precise-build/salt/roots/build_deps.sls
+++ b/vagrant/precise-build/salt/roots/build_deps.sls
@@ -1,15 +1,3 @@
-install_salt:
-    pkgrepo.managed:
-    - humanname: salt PPA
-    - name: deb http://ppa.launchpad.net/saltstack/salt/ubuntu precise main
-    - dist: precise
-    - file: /etc/apt/sources.list.d/saltstack.list
-    - keyid: 0E27C0A6
-    - keyserver: keyserver.ubuntu.com
-    pkg.latest:
-    - name: salt-master
-    - refresh: True
-
 build_deps:
   pkg.installed:
     - pkgs:

--- a/vagrant/precise-build/salt/roots/git_clone.sls
+++ b/vagrant/precise-build/salt/roots/git_clone.sls
@@ -1,26 +1,19 @@
+{% import 'setvars' as vars %}
+
 calamari_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/calamari
-    - name: /git/calamari
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/calamari
+    - name: {{vars.gitpath}}/calamari
     - require:
       - pkg: build_deps
 
 diamond_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/Diamond
-    - name: /git/Diamond
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/Diamond
+    - name: {{vars.gitpath}}/Diamond
     - require:
       - pkg: build_deps
-
-#salt_clone:
-#  git:
-#    - latest
-#    - user: vagrant
-#    - target: /home/vagrant/calamari-salt
-#    - name: /git/calamari-salt
-#    - require:
-#      - pkg: build_deps

--- a/vagrant/precise-build/salt/roots/make_packages.sls
+++ b/vagrant/precise-build/salt/roots/make_packages.sls
@@ -1,35 +1,37 @@
+{% import 'setvars' as vars %}
+
 build-diamond:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make deb
-    - cwd: /home/vagrant/Diamond
+    - cwd: {{vars.builddir}}/Diamond
     - require:
-      - git: /git/Diamond
+      - git: {{vars.gitpath}}/Diamond
 
 build-repo:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make precise
-    - cwd: /home/vagrant/calamari/repobuild
+    - cwd: {{vars.builddir}}/calamari/repobuild
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
       - cmd: build-diamond
 
 build-calamari-server:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make dpkg
-    - cwd: /home/vagrant/calamari
+    - cwd: {{vars.builddir}}/calamari
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-precise.tar.gz',
+{% for path in ('calamari/repobuild/calamari-repo-*.tar.gz',
                 'calamari-server_*.deb',
                 'Diamond/build/diamond_*.deb') %}
 
 cp-artifacts-to-share {{ path }}:
   cmd.run:
-    - name: cp {{ path }} /git/
-    - cwd: /home/vagrant/
+    - name: cp {{ path }} {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
 
 {% endfor %}

--- a/vagrant/precise-build/salt/roots/setvars
+++ b/vagrant/precise-build/salt/roots/setvars
@@ -1,0 +1,16 @@
+{% set username = salt['environ.get']('SUDO_USER', 'vagrant') %}
+
+{% if username == 'vagrant' %}
+
+{%    set gitpath = '/git' %}
+{%    set builddir = '/home/vagrant' %}
+{%    set pkgdest = gitpath %}
+
+{% else %}
+
+{%    set gitpath = 'git://github.com/ceph' %}
+{%    set builddir = salt['environ.get']('WORKSPACE', salt['user.info'](username)['home']) %}
+{%    set pkgdest = builddir %}
+
+{% endif %}
+

--- a/vagrant/rhel-build/Vagrantfile
+++ b/vagrant/rhel-build/Vagrantfile
@@ -14,11 +14,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "rhel64"
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 512
+    v.memory = 1024
   end
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "512"]
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//git", "1"]
   end
 

--- a/vagrant/rhel-build/salt/roots/build_deps.sls
+++ b/vagrant/rhel-build/salt/roots/build_deps.sls
@@ -1,13 +1,3 @@
-install_salt:
-    pkgrepo.managed:
-    - humanname: EPEL
-    - mirrorlist: http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
-    - gpgcheck: 1
-    - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
-    pkg.latest:
-    - name: salt-master
-    - refresh: True
-
 build_deps:
   pkg.installed:
     - pkgs:

--- a/vagrant/rhel-build/salt/roots/git_clone.sls
+++ b/vagrant/rhel-build/salt/roots/git_clone.sls
@@ -1,18 +1,19 @@
+{% import 'setvars' as vars %}
+
 calamari_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/calamari
-    - name: /git/calamari
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/calamari
+    - name: {{vars.gitpath}}/calamari
     - require:
       - pkg: build_deps
 
 diamond_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/Diamond
-    - name: /git/Diamond
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/Diamond
+    - name: {{vars.gitpath}}/Diamond
     - require:
       - pkg: build_deps
-

--- a/vagrant/rhel-build/salt/roots/make_packages.sls
+++ b/vagrant/rhel-build/salt/roots/make_packages.sls
@@ -1,35 +1,37 @@
+{% import 'setvars' as vars %}
+
 build-diamond:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make rpm
-    - cwd: /home/vagrant/Diamond
+    - cwd: {{vars.builddir}}/Diamond
     - require:
-      - git: /git/Diamond
+      - git: {{vars.gitpath}}/Diamond
 
 build-repo:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make rhel6
-    - cwd: /home/vagrant/calamari/repobuild
+    - cwd: {{vars.builddir}}/calamari/repobuild
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
       - cmd: build-diamond
 
 build-calamari-server:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: ./build-rpm.sh
-    - cwd: /home/vagrant/calamari
+    - cwd: {{vars.builddir}}/calamari
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-rhel6.tar.gz',
-                'rpmbuild/RPMS/x86_64/calamari-server-*.rpm',
-                'Diamond/dist/diamond-*.noarch.rpm') %}
+{% for path in ('calamari/repobuild/calamari-repo-*.tar.gz',
+                'rpmbuild/RPMS/*/calamari-server-*.rpm',
+                'Diamond/dist/diamond-*.rpm') %}
 
 cp-artifacts-to-share {{ path }}:
   cmd.run:
-    - name: cp {{ path }} /git/
-    - cwd: /home/vagrant/
+    - name: cp {{ path }} {{vars.pkgdest}} 
+    - cwd: {{vars.builddir}}
 
 {% endfor %}

--- a/vagrant/rhel-build/salt/roots/setvars
+++ b/vagrant/rhel-build/salt/roots/setvars
@@ -1,0 +1,16 @@
+{% set username = salt['environ.get']('SUDO_USER', 'vagrant') %}
+
+{% if username == 'vagrant' %}
+
+{%    set gitpath = '/git' %}
+{%    set builddir = '/home/vagrant' %}
+{%    set pkgdest = gitpath %}
+
+{% else %}
+
+{%    set gitpath = 'git://github.com/ceph' %}
+{%    set builddir = salt['environ.get']('WORKSPACE', salt['user.info'](username)['home']) %}
+{%    set pkgdest = builddir %}
+
+{% endif %}
+

--- a/vagrant/rhel7-build/Vagrantfile
+++ b/vagrant/rhel7-build/Vagrantfile
@@ -14,11 +14,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "rhel7"
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 512
+    v.memory = 1024
   end
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "512"]
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//git", "1"]
   end
 

--- a/vagrant/rhel7-build/salt/roots/build_deps.sls
+++ b/vagrant/rhel7-build/salt/roots/build_deps.sls
@@ -1,17 +1,3 @@
-# this seems not to be necessary in general, but certainly not 
-# necessary here as we're currently provisioning with the 'develop'
-# branch, which is about as new as you can get
-
-#install_salt:
-#    pkgrepo.managed:
-#    - humanname: EPEL
-#    - mirrorlist: http://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=x86_64
-#    - gpgcheck: 1
-#    - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
-#    pkg.latest:
-#    - name: salt-master
-#    - refresh: True
-
 build_deps:
   pkg.installed:
     - pkgs:

--- a/vagrant/rhel7-build/salt/roots/git_clone.sls
+++ b/vagrant/rhel7-build/salt/roots/git_clone.sls
@@ -1,18 +1,19 @@
+{% import 'setvars' as vars %}
+
 calamari_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/calamari
-    - name: /git/calamari
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/calamari
+    - name: {{vars.gitpath}}/calamari
     - require:
       - pkg: build_deps
 
 diamond_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/Diamond
-    - name: /git/Diamond
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/Diamond
+    - name: {{vars.gitpath}}/Diamond
     - require:
       - pkg: build_deps
-

--- a/vagrant/rhel7-build/salt/roots/make_packages.sls
+++ b/vagrant/rhel7-build/salt/roots/make_packages.sls
@@ -1,35 +1,37 @@
+{% import 'setvars' as vars %}
+
 build-diamond:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make rpm
-    - cwd: /home/vagrant/Diamond
+    - cwd: {{vars.builddir}}/Diamond
     - require:
-      - git: /git/Diamond
+      - git: {{vars.gitpath}}/Diamond
 
 build-repo:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make rhel7
-    - cwd: /home/vagrant/calamari/repobuild
+    - cwd: {{vars.builddir}}/calamari/repobuild
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
       - cmd: build-diamond
 
 build-calamari-server:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: ./build-rpm.sh
-    - cwd: /home/vagrant/calamari
+    - cwd: {{vars.builddir}}/calamari
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-rhel7.tar.gz',
-                'rpmbuild/RPMS/x86_64/calamari-server-*.rpm',
-                'Diamond/dist/diamond-*.noarch.rpm') %}
+{% for path in ('calamari/repobuild/calamari-repo-*.tar.gz',
+                'rpmbuild/RPMS/*/calamari-server-*.rpm',
+                'Diamond/dist/diamond-*.rpm') %}
 
 cp-artifacts-to-share {{ path }}:
   cmd.run:
-    - name: cp {{ path }} /git/
-    - cwd: /home/vagrant/
+    - name: cp {{ path }} {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
 
 {% endfor %}

--- a/vagrant/rhel7-build/salt/roots/setvars
+++ b/vagrant/rhel7-build/salt/roots/setvars
@@ -1,0 +1,16 @@
+{% set username = salt['environ.get']('SUDO_USER', 'vagrant') %}
+
+{% if username == 'vagrant' %}
+
+{%    set gitpath = '/git' %}
+{%    set builddir = '/home/vagrant' %}
+{%    set pkgdest = gitpath %}
+
+{% else %}
+
+{%    set gitpath = 'git://github.com/ceph' %}
+{%    set builddir = salt['environ.get']('WORKSPACE', salt['user.info'](username)['home']) %}
+{%    set pkgdest = builddir %}
+
+{% endif %}
+

--- a/vagrant/trusty-build/salt/roots/build_deps.sls
+++ b/vagrant/trusty-build/salt/roots/build_deps.sls
@@ -1,15 +1,3 @@
-install_salt:
-    pkgrepo.managed:
-    - humanname: salt PPA
-    - name: deb http://ppa.launchpad.net/saltstack/salt/ubuntu trusty main
-    - dist: trusty
-    - file: /etc/apt/sources.list.d/saltstack.list
-    - keyid: 0E27C0A6
-    - keyserver: keyserver.ubuntu.com
-    pkg.latest:
-    - name: salt-master
-    - refresh: True
-
 build_deps:
   pkg.installed:
     - pkgs:

--- a/vagrant/trusty-build/salt/roots/git_clone.sls
+++ b/vagrant/trusty-build/salt/roots/git_clone.sls
@@ -1,26 +1,19 @@
+{% import 'setvars' as vars %}
+
 calamari_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/calamari
-    - name: /git/calamari
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/calamari
+    - name: {{vars.gitpath}}/calamari
     - require:
       - pkg: build_deps
 
 diamond_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/Diamond
-    - name: /git/Diamond
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/Diamond
+    - name: {{vars.gitpath}}/Diamond
     - require:
       - pkg: build_deps
-
-#salt_clone:
-#  git:
-#    - latest
-#    - user: vagrant
-#    - target: /home/vagrant/calamari-salt
-#    - name: /git/calamari-salt
-#    - require:
-#      - pkg: build_deps

--- a/vagrant/trusty-build/salt/roots/make_packages.sls
+++ b/vagrant/trusty-build/salt/roots/make_packages.sls
@@ -1,35 +1,37 @@
+{% import 'setvars' as vars %}
+
 build-diamond:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make deb
-    - cwd: /home/vagrant/Diamond
+    - cwd: {{vars.builddir}}/Diamond
     - require:
-      - git: /git/Diamond
+      - git: {{vars.gitpath}}/Diamond
 
 build-repo:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make trusty
-    - cwd: /home/vagrant/calamari/repobuild
+    - cwd: {{vars.builddir}}/calamari/repobuild
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
       - cmd: build-diamond
 
 build-calamari-server:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make dpkg
-    - cwd: /home/vagrant/calamari
+    - cwd: {{vars.builddir}}/calamari
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-trusty.tar.gz',
+{% for path in ('calamari/repobuild/calamari-repo-*.tar.gz',
                 'calamari-server_*.deb',
                 'Diamond/build/diamond_*.deb') %}
 
 cp-artifacts-to-share {{ path }}:
   cmd.run:
-    - name: cp {{ path }} /git/
-    - cwd: /home/vagrant/
+    - name: cp {{ path }} {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
 
 {% endfor %}

--- a/vagrant/trusty-build/salt/roots/setvars
+++ b/vagrant/trusty-build/salt/roots/setvars
@@ -1,0 +1,16 @@
+{% set username = salt['environ.get']('SUDO_USER', 'vagrant') %}
+
+{% if username == 'vagrant' %}
+
+{%    set gitpath = '/git' %}
+{%    set builddir = '/home/vagrant' %}
+{%    set pkgdest = gitpath %}
+
+{% else %}
+
+{%    set gitpath = 'git://github.com/ceph' %}
+{%    set builddir = salt['environ.get']('WORKSPACE', salt['user.info'](username)['home']) %}
+{%    set pkgdest = builddir %}
+
+{% endif %}
+

--- a/vagrant/wheezy-build/Vagrantfile
+++ b/vagrant/wheezy-build/Vagrantfile
@@ -9,11 +9,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "wheezy64"
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 512
+    v.memory = 1024
   end
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "512"]
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//git", "1"]
   end
 

--- a/vagrant/wheezy-build/salt/roots/build_deps.sls
+++ b/vagrant/wheezy-build/salt/roots/build_deps.sls
@@ -1,14 +1,3 @@
-install_salt:
-    pkgrepo.managed:
-    - humanname: salt wheezy
-    - name: deb http://debian.saltstack.com/debian wheezy-saltstack main
-    - dist: wheezy-saltstack
-    - file: /etc/apt/sources.list.d/saltstack.list
-    - keyurl: http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key
-    pkg.latest:
-    - name: salt-master
-    - refresh: True
-
 build_deps:
   pkg.installed:
     - pkgs:

--- a/vagrant/wheezy-build/salt/roots/git_clone.sls
+++ b/vagrant/wheezy-build/salt/roots/git_clone.sls
@@ -1,26 +1,19 @@
+{% import 'setvars' as vars %}
+
 calamari_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/calamari
-    - name: /git/calamari
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/calamari
+    - name: {{vars.gitpath}}/calamari
     - require:
       - pkg: build_deps
 
 diamond_clone:
   git:
     - latest
-    - user: vagrant
-    - target: /home/vagrant/Diamond
-    - name: /git/Diamond
+    - user: {{vars.username}}
+    - target: {{vars.builddir}}/Diamond
+    - name: {{vars.gitpath}}/Diamond
     - require:
       - pkg: build_deps
-
-#salt_clone:
-#  git:
-#    - latest
-#    - user: vagrant
-#    - target: /home/vagrant/calamari-salt
-#    - name: /git/calamari-salt
-#    - require:
-#      - pkg: build_deps

--- a/vagrant/wheezy-build/salt/roots/make_packages.sls
+++ b/vagrant/wheezy-build/salt/roots/make_packages.sls
@@ -1,35 +1,37 @@
+{% import 'setvars' as vars %}
+
 build-diamond:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make deb
-    - cwd: /home/vagrant/Diamond
+    - cwd: {{vars.builddir}}/Diamond
     - require:
-      - git: /git/Diamond
+      - git: {{vars.gitpath}}/Diamond
 
 build-repo:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make wheezy
-    - cwd: /home/vagrant/calamari/repobuild
+    - cwd: {{vars.builddir}}/calamari/repobuild
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
       - cmd: build-diamond
 
 build-calamari-server:
   cmd.run:
-    - user: vagrant
+    - user: {{vars.username}}
     - name: make dpkg
-    - cwd: /home/vagrant/calamari
+    - cwd: {{vars.builddir}}/calamari
     - require:
-      - git: /git/calamari
+      - git: {{vars.gitpath}}/calamari
 
-{% for path in ('calamari/repobuild/calamari-repo-wheezy.tar.gz',
+{% for path in ('calamari/repobuild/calamari-repo-*.tar.gz',
                 'calamari-server_*.deb',
                 'Diamond/build/diamond_*.deb') %}
 
 cp-artifacts-to-share {{ path }}:
   cmd.run:
-    - name: cp {{ path }} /git/
-    - cwd: /home/vagrant/
+    - name: cp {{ path }} {{vars.pkgdest}}
+    - cwd: {{vars.builddir}}
 
 {% endfor %}

--- a/vagrant/wheezy-build/salt/roots/setvars
+++ b/vagrant/wheezy-build/salt/roots/setvars
@@ -1,0 +1,16 @@
+{% set username = salt['environ.get']('SUDO_USER', 'vagrant') %}
+
+{% if username == 'vagrant' %}
+
+{%    set gitpath = '/git' %}
+{%    set builddir = '/home/vagrant' %}
+{%    set pkgdest = gitpath %}
+
+{% else %}
+
+{%    set gitpath = 'git://github.com/ceph' %}
+{%    set builddir = salt['environ.get']('WORKSPACE', salt['user.info'](username)['home']) %}
+{%    set pkgdest = builddir %}
+
+{% endif %}
+


### PR DESCRIPTION
Allow the salt structure to be used with or without Vagrant.  Also, make all vagrant VMs 1024k (some were 
consistently running out of memory).