### PR TITLE
make get-versions.sh respect light-weight tags

### DIFF
--- a/get-versions.sh
+++ b/get-versions.sh
@@ -12,7 +12,7 @@ RPM='n'
 if [ "$1" == "-r" ] ; then RPM='y' ; shift ; fi
 
 # GITVER is the version from the current git branch, less the first char ('v')
-GITVER=$(git describe | cut -c 2-)
+GITVER=$(git describe --tags | cut -c 2-)
 
 # if GITVER contains a '-', separate at the first one into version and revision
 if [[ $GITVER == *-* ]]; then


### PR DESCRIPTION
Some Git tags in Calamari are currently light-weight (not annotated).

Add the `--tags` flag to the `git describe` command so that `get-version.sh` recognizes lightweight tags.

(Adding @branto1 to the CC in case he wants to review)