### PR TITLE
Handle VERSION in a more future-proof way

### DIFF
--- a/get-flavor.sh
+++ b/get-flavor.sh
@@ -16,8 +16,8 @@ VERSION=$(lsb_release -r -s)
 case $ID in
     "CentOS"|"RedHatEnterpriseServer")
         case $VERSION in
-            "7.0") ret="rhel7" ;;
-            "6.5"|"6.4"|"6.3") ret="el6" ;;
+            7.*) ret="rhel7" ;;
+            6.*) ret="el6" ;;
             *) echo "$0: unhandled EL version $VERSION"; exit 1 ;;
         esac ;;
     "Ubuntu"|"Debian") ret="debian" ;;


### PR DESCRIPTION
Do not look for specific strings in VERSION field, just use the shell
built-in pattern matching mechanism.