### PR TITLE
calamari.spec: avoid sudo in RPM %post instructions

### DIFF
--- a/calamari.spec
+++ b/calamari.spec
@@ -102,7 +102,7 @@ service httpd start
 # part of the installation process
 echo "Thank you for installing Calamari."
 echo ""
-echo "Please run 'sudo calamari-ctl initialize' to complete the installation."
+echo "Please run 'calamari-ctl initialize' as root to complete the installation."
 exit 0
 
 %preun -n calamari-server


### PR DESCRIPTION
Prior to this pull request, during the RPM installation, a message would be printed to STDOUT that tells the user to run calamari-ctl using sudo.

Not all Red Hat systems are set up for sudo. Update the message to use the more general instruction "run X as root" instead.

This change comes from Boris Ranto @branto1 , from the downstream Red Hat Ceph Storage packages.
