### PR TITLE
calamari.spec: simplify log files lists

### DIFF
--- a/calamari.spec
+++ b/calamari.spec
@@ -52,16 +52,14 @@ browser.
 %{_sysconfdir}/httpd/conf.d/calamari.conf
 %{_sysconfdir}/calamari/
 /usr/bin/calamari-ctl
-%dir /var/log/calamari
-%dir /var/log/graphite
+%dir %attr (755, apache, apache) /var/log/calamari
+%dir %attr (755, apache, apache) /var/log/graphite
 %dir /var/lib/calamari
 %dir /var/lib/cthulhu
 %dir /var/lib/graphite
 %dir /var/lib/graphite/log
 %dir /var/lib/graphite/log/webapp
 %dir /var/lib/graphite/whisper
-%attr (755, apache, apache) /var/log/calamari
-%attr (755, apache, apache) /var/log/graphite
 
 %post -n calamari-server
 calamari_httpd()


### PR DESCRIPTION
RPM permits us to combine the `%dir` and `%attr` RPM macros on the same lines in the `%files` lists. This allows us to reduce duplication in the `%files` list by only specifying the `/var/log` locations once instead of specifying them twice.

This change comes from @branto1 , from the downstream Red Hat Ceph Storage packages.