### PR TITLE
cthulhu: make it work with salt 2015.5.0

### DIFF
--- a/calamari-common/calamari_common/salt_wrapper.py
+++ b/calamari-common/calamari_common/salt_wrapper.py
@@ -25,7 +25,11 @@ try:
     from salt.config import master_config  # noqa
     from salt.utils.master import MasterPillarUtil  # noqa
     from salt.config import client_config  # noqa
-    from salt.loader import _create_loader
+    try:
+        from salt.loader import _create_loader
+    except ImportError:
+        # Salt removed this in b0e1425
+        from salt.loader import static_loader as _create_loader
 except ImportError:
     condition_kwarg = None
     LocalClient = None


### PR DESCRIPTION
Replace salt.loader.static_loader from newer
salt versions with _create_loader, which is
compatible with older salt versions.

Signed-off-by: Alex Muntada <alexm@alexm.org>