### PR TITLE
Handle OSDs that do not exist

### DIFF
--- a/calamari-common/calamari_common/types.py
+++ b/calamari-common/calamari_common/types.py
@@ -213,7 +213,10 @@ class OsdMap(VersionedSyncObject):
         osds = dict([(osd_id, []) for osd_id in self.osds_by_id.keys()])
         for pool_id in self.pools_by_id.keys():
             for in_pool_id in self.osds_by_pool[pool_id]:
-                osds[in_pool_id].append(pool_id)
+                try:
+                    osds[in_pool_id].append(pool_id)
+                except KeyError:
+                    log.warning("OSD {0} is present in CRUSH map, but not in OSD map")
 
         return osds
 

--- a/cthulhu/cthulhu/manager/server_monitor.py
+++ b/cthulhu/cthulhu/manager/server_monitor.py
@@ -663,9 +663,13 @@ class ServerMonitor(greenlet.Greenlet):
                 # Go find the OSD in the OSD map and tell me its frontend and backend addrs
                 osd_map = cluster.get_sync_object_data(OsdMap)
                 if osd_map is not None:
-                    osd = [osd for osd in osd_map['osds'] if str(osd['osd']) == service.service_id][0]
-                    frontend_addr = osd['public_addr'].split(":")[0]
-                    backend_addr = osd['cluster_addr'].split(":")[0]
+                    osd = [osd for osd in osd_map['osds'] if str(osd['osd']) == service.service_id]
+                    # osd can be empty at this point if the OSD is DNE (it's
+                    # in server_state.services, but not in the osd_map)
+                    if len(osd) > 0:
+                        osd = osd[0]
+                        frontend_addr = osd['public_addr'].split(":")[0]
+                        backend_addr = osd['cluster_addr'].split(":")[0]
 
         return {
             'fqdn': server_state.fqdn,


### PR DESCRIPTION
There's a slightly bizarre edge case, where if you have an OSD in DNE
state (i.e. it's in the CRUSH map, but doesn't actually exist), this
causes various errors (IndexError, NotFound etc.) due to the osd_map
being out of sync with both the crush map and service state.  For
initial discussion of this problem, see:

http://lists.ceph.com/pipermail/ceph-calamari-ceph.com/2015-May/000092.html

This fix injects a fake OSD at the lowest level possible, which means
it appears everywhere it should, and can be displayed in a suitably
scary red color.

Note that the injected fake OSD may not have the best values for its
attributes -- most/all of them seem to need to exist, but perhaps should
default to "unknown" or empty strings rather than my excessive use of
"DNE".

Signed-off-by: Tim Serong <tserong@suse.com>