### PR TITLE
rest-api and documentation: Update server_metadata.py to work with 2015.5.1 static_loader, and update documentation and vagrant files to work around an issue with m2crypto on later releases of Centos/Rhel/Fedora

### DIFF
--- a/doc/development/dev_env.rst
+++ b/doc/development/dev_env.rst
@@ -64,7 +64,7 @@ For RH systems:
 
 1. Create a virtualenv (if you are on ubuntu and using systemwide installs of
    cairo and m2crypto, then pass *--system-site-packages*)
-2. Install dependencies with ``pip install -r requirements/{2.6,2.7}/requirements.txt`` and ``pip install -r requirements/{2.6,2.7}/requirements.force.txt``. Where {2.6,2.7} should represent the system version of python.
+2. Install dependencies with ``SWIG_FEATURES=-cpperraswarn pip install -r requirements/{2.6,2.7}/requirements.txt`` and ``pip install -r requirements/{2.6,2.7}/requirements.force.txt``. Where {2.6,2.7} should represent the system version of python.
 3. Install graphite and carbon, which require some special command lines:
 
 ::

--- a/vagrant/devmode/salt/roots/virtualenv.sls
+++ b/vagrant/devmode/salt/roots/virtualenv.sls
@@ -29,6 +29,7 @@ pip_pkgs:
     - activate: true
     - requirements: /home/vagrant/calamari/requirements/2.7/requirements.txt
     - download_cache: /vagrant/pip_cache
+    - env_vars: SWIG_FEATURES=-cpperraswarn
     - require:
       - virtualenv: virtualenv
       - pip: pyzmq


### PR DESCRIPTION
…k around m2crypto build problems, and update the salt version dependency in the requirements.txt files.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hp.com>