### PR TITLE
types.py: Fixup missing crush_node_by_id initialization when data is set to None

### DIFF
--- a/calamari-common/calamari_common/types.py
+++ b/calamari-common/calamari_common/types.py
@@ -67,6 +67,7 @@ class OsdMap(VersionedSyncObject):
             self.osds_by_id = {}
             self.pools_by_id = {}
             self.osd_tree_node_by_id = {}
+            self.crush_node_by_id = {}
             self.flags = dict([(x, False) for x in OSD_FLAGS])
 
     def _filter_crush_nodes(self, nodes):


### PR DESCRIPTION
Submitted fix for #311, let me know what you think.