### PR TITLE
calamari-ctl: Fix "No minions matched the target" when updating minions

### DIFF
--- a/cthulhu/cthulhu/calamari_ctl.py
+++ b/cthulhu/cthulhu/calamari_ctl.py
@@ -179,9 +179,15 @@ def create_admin_users(args):
 
 
 def update_connected_minions():
+    from cthulhu.manager import config
+    from calamari_common.salt_wrapper import Key, master_config
+    if len(Key(master_config(config.get('cthulhu', 'salt_config_path'))).list_keys()['minions']) == 0:
+        # no minions to update
+        return
+
     message = "Updating already connected nodes."
     log.info(message)
-    p = subprocess.Popen(["salt", "'*'", "state.highstate"],
+    p = subprocess.Popen(["salt", "*", "state.highstate"],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
     log.debug("{message} salt stdout: {out}".format(message=message, out=out))


### PR DESCRIPTION
@tserong Thank you! 
Noticed this from the mailing list and it works for me.

This fixes two problems:

1) Popen(["salt"], "'*'", "state.highstate"]) passes '*' i.e. a single
quoted star to salt, which doesn't work - it needs to be a bare star,
else it can't match hostnames, and returns rc=2 causing calamari-ctl
initialize to report a failure ("No minions matched the target. No
command was sent, no jid was assigned").

2) salt * state.highstate fails with the same error on the first run, if
there are no connected minions.

Signed-off-by: Tim Serong <tserong@suse.com>
(cherry picked from commit f54cf4259c5b6629269118b4b909f6418a69dc40)