### PR TITLE
Revert "calamari.spec: avoid sudo in RPM %post instructions"

### DIFF
--- a/calamari.spec
+++ b/calamari.spec
@@ -161,7 +161,7 @@ service httpd start
 # part of the installation process
 echo "Thank you for installing Calamari."
 echo ""
-echo "Please run 'calamari-ctl initialize' as root to complete the installation."
+echo "Please run 'sudo calamari-ctl initialize' to complete the installation."
 exit 0
 
 %preun -n calamari-server


### PR DESCRIPTION
This reverts commit 7be2fb1f1970f66b7dfcbd37aebaab7017cbb128.

Originally I thought that we should avoid sudo, but we decided to reverse that decision and now we're standardizing on sudo everywhere.

Add "sudo" back to the RPM %post instructions.