### PR TITLE
Wip fix devmode

### DIFF
--- a/tests/calamari_ctl.py
+++ b/tests/calamari_ctl.py
@@ -38,8 +38,6 @@ class CalamariControl(object):
 
     def __init__(self):
         log.info("CalamariControl.__init__")
-        with open(config.get('testing', 'external_cluster_path')) as f:
-            self.cluster_config = yaml.load(f)
         self._api = None
 
     def start(self):


### PR DESCRIPTION
@dmick I thought we relaxed the requirement for info.yaml already
For some reason this fails to rebase cleanly to 1.2.3 hence the DNM