### PR TITLE
devmode: move to trusty from precise

### DIFF
--- a/vagrant/devmode/Vagrantfile
+++ b/vagrant/devmode/Vagrantfile
@@ -5,8 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "boxcutter/ubuntu1404"
 
   # Use a bridged network so that external Ceph servers can connect to
   # salt master on this VM.
@@ -15,6 +14,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder "../../", "/calamari.git"
   config.vm.synced_folder "salt/roots/", "/srv/salt/"
   config.vm.provision :salt do |salt|
+    salt.bootstrap_options = "-P"
     salt.minion_config = "salt/minion"
     salt.run_highstate = true
   end

--- a/vagrant/devmode/salt/roots/build_deps.sls
+++ b/vagrant/devmode/salt/roots/build_deps.sls
@@ -10,8 +10,8 @@ build_deps:
       - python-cairo
       - python-m2crypto
       - make
-      - postgresql-9.1
-      - postgresql-server-dev-9.1
+      - postgresql
+      - postgresql-server-dev-all
       - python-pip
       - libevent-dev
       - libmysqlclient-dev


### PR DESCRIPTION
salt-bootstrap is broken on precise, this is the easiest transition
to get it working