### PR TITLE
cthulhu: Fail correct UserRequests when choosing a new favorite mon

### DIFF
--- a/cthulhu/cthulhu/manager/cluster_monitor.py
+++ b/cthulhu/cthulhu/manager/cluster_monitor.py
@@ -385,7 +385,7 @@ class ClusterMonitor(gevent.greenlet.Greenlet):
 
     def _set_favorite(self, minion_id):
         assert minion_id != self._favorite_mon
-        self._requests.fail_all(minion_id)
+        self._requests.fail_all(self._favorite_mon, self.fsid)
 
         self._favorite_mon = minion_id
 

--- a/cthulhu/cthulhu/manager/request_collection.py
+++ b/cthulhu/cthulhu/manager/request_collection.py
@@ -141,12 +141,14 @@ class RequestCollection(object):
                 # any guarantees because running nodes may be out of touch with the calamari server.
 
     @nosleep
-    def fail_all(self, failed_minion):
+    def fail_all(self, failed_minion, fsid):
         """
         For use when we lose contact with the minion that was in use for running
         requests: assume all these requests are never going to return now.
         """
         for request in self.get_all(UserRequest.SUBMITTED):
+            if request.fsid != fsid:
+                continue
             with self._update_index(request):
                 request.set_error("Lost contact with server %s" % failed_minion)
                 if request.jid:


### PR DESCRIPTION
cluster_monitor watches a specific cluster FSID
request_collection is a collection of all requests in all clusters
This fix changes the filter that request_collection uses when fail_all()
is called.

Fixes: #13173

Signed-off-by: Gregory Meno <gmeno@redhat.com>