### PR TITLE
rest-api: fix typo in url routing for osd/command

### DIFF
--- a/rest-api/calamari_rest/urls/v2.py
+++ b/rest-api/calamari_rest/urls/v2.py
@@ -68,7 +68,7 @@ urlpatterns = patterns(
     url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/osd/(?P<osd_id>\d+)$',
         calamari_rest.views.v2.OsdViewSet.as_view({'get': 'retrieve', 'patch': 'update'}),
         name='cluster-osd-detail'),
-    url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/osd /command$',
+    url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/osd/command$',
         calamari_rest.views.v2.OsdViewSet.as_view({'get': 'get_implemented_commands'})),
     url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/osd/(?P<osd_id>\d+)/command$',
         calamari_rest.views.v2.OsdViewSet.as_view({'get': 'get_valid_commands'})),


### PR DESCRIPTION
Signed-off-by: Gregory Meno <gmeno@redhat.com>