### PR TITLE
fix so that it also works with centos and the like

### DIFF
--- a/salt/srv/salt/diamond.sls
+++ b/salt/srv/salt/diamond.sls
@@ -35,7 +35,7 @@ diamond-network-config:
     - require:
         - pkg: diamond
 
-{% if grains['os'] == 'RedHat' and grains['osrelease'].startswith('7') %}
+{% if grains['os_family'] == 'RedHat' and grains['osrelease'].startswith('7') %}
 # work around https://github.com/saltstack/salt/pull/12316
 diamond:
   pkg:


### PR DESCRIPTION
grains['os'] == 'RedHat' really just works out for RHEL but not for centos and co.

whereas grains['os_family'] == 'RedHat' also works for the later