### PR TITLE
add %dir directive

### DIFF
--- a/calamari.spec
+++ b/calamari.spec
@@ -61,8 +61,8 @@ browser.
 %dir /var/lib/graphite/log
 %dir /var/lib/graphite/log/webapp
 %dir /var/lib/graphite/whisper
-%attr (755, apache, apache) /var/log/calamari
-%attr (755, apache, apache) /var/log/graphite
+%dir %attr (755, apache, apache) /var/log/calamari
+%dir %attr (755, apache, apache) /var/log/graphite
 
 %post -n calamari-server
 calamari_httpd()


### PR DESCRIPTION
@ktdreyer @dmick 

The problem is that the rest-api errors out with an IOError: permission
denied as it imports the salt_wrapper and the wrapper tries to intialize
a logHandler for cthulhu.log

This wrapper wants to log import
failures to both calamari.log and cthulhu.log. Because it doesn't know
who is using it. A better fix might be to pass in a logHandler

Without this patch
cthulhu.log will be owned by root as cthulhu runs as root.

The fix is to chown all the log files in /var/log/calamari to the apache
user.

Signed-off-by: Gregory Meno <gmeno@redhat.com>