### PR TITLE
Corrected the page size variable from page count.

### DIFF
--- a/doc/calamari_rest/conventions.rst
+++ b/doc/calamari_rest/conventions.rst
@@ -79,7 +79,7 @@ of a list, where the list of results is in the ``results`` attribute and the tot
 objects available is in the ``count`` attribute.
 
 To control the page returned and the page size returned, use the ``page`` (counting from 1) and
-``page_count`` parameters respectively.  For example, the following contrived example returns
+``page_size`` parameters respectively.  For example, the following contrived example returns
 only the first two events for a cluster:
 
 ::


### PR DESCRIPTION
Corrected the variable name specified in the description to that specified in the example.