### PR TITLE
Cthulhu: Optionally push events to salt event bus

### DIFF
--- a/conf/calamari/debian/calamari.conf
+++ b/conf/calamari/debian/calamari.conf
@@ -15,6 +15,8 @@ db_log_level = WARN
 favorite_timeout_factor = 3
 server_timeout_factor = 3
 cluster_contact_threshold = 60
+emit_events_to_salt_event_bus = False
+event_tag_prefix = calamari/
 
 [calamari_web]
 

--- a/conf/calamari/el6/calamari.conf
+++ b/conf/calamari/el6/calamari.conf
@@ -15,6 +15,8 @@ db_log_level = WARN
 favorite_timeout_factor = 3
 server_timeout_factor = 3
 cluster_contact_threshold = 60
+emit_events_to_salt_event_bus = False
+event_tag_prefix = calamari/
 
 [calamari_web]
 

--- a/conf/calamari/rhel7/calamari.conf
+++ b/conf/calamari/rhel7/calamari.conf
@@ -15,6 +15,8 @@ db_log_level = WARN
 favorite_timeout_factor = 3
 server_timeout_factor = 3
 cluster_contact_threshold = 60
+emit_events_to_salt_event_bus = False
+event_tag_prefix = calamari/
 
 [calamari_web]
 

--- a/conf/calamari/suse/calamari.conf
+++ b/conf/calamari/suse/calamari.conf
@@ -15,6 +15,8 @@ db_log_level = WARN
 favorite_timeout_factor = 3
 server_timeout_factor = 3
 cluster_contact_threshold = 60
+emit_events_to_salt_event_bus = False
+event_tag_prefix = calamari/
 
 [calamari_web]
 

--- a/dev/calamari.conf.template
+++ b/dev/calamari.conf.template
@@ -15,6 +15,8 @@ db_log_level = WARN
 favorite_timeout_factor = 3
 server_timeout_factor = 3
 cluster_contact_threshold = 60
+emit_events_to_salt_event_bus = False
+event_tag_prefix = calamari/
 
 [calamari_web]
 

--- a/doc/calamari.conf
+++ b/doc/calamari.conf
@@ -15,6 +15,8 @@ db_log_level = WARN
 favorite_timeout_factor = 3
 server_timeout_factor = 3
 cluster_contact_threshold = 60
+emit_events_to_salt_event_bus = False
+event_tag_prefix = calamari/
 
 [calamari_web]
 


### PR DESCRIPTION
This patch adds an option to push events generated by
calamari to salt event bus. This can be enabled by
setting the option emit_event_to_salt_event_bus to True,
by default this will be set to false. Also there is an
option to set the prefix of the tag of the event pushed.
This can be done using the option "event_tag_prefix". By
default its value is "calamari/". These options are
available in calamari.conf file under [cthulhu].

Signed-off-by: Darshan N <dnarayan@redhat.com>