### PR TITLE
calamari-common: log salt import failures with supervisor

### DIFF
--- a/calamari-common/calamari_common/salt_wrapper.py
+++ b/calamari-common/calamari_common/salt_wrapper.py
@@ -11,49 +11,25 @@ environment.
 import gevent
 import logging
 
-from calamari_common.config import CalamariConfig
-
-FORMAT = "%(asctime)s - %(levelname)s - %(name)s %(message)s"
-log = logging.getLogger(__name__)
-config = CalamariConfig()
-
-# log to cthulhu.log
-handler = logging.FileHandler(config.get('cthulhu', 'log_path'))
-handler.setFormatter(logging.Formatter(FORMAT))
-log.addHandler(handler)
-
-# log to calamari.log
-handler = logging.FileHandler(config.get('calamari_web', 'log_path'))
-handler.setFormatter(logging.Formatter(FORMAT))
-log.addHandler(handler)
-
-log.addHandler(logging.StreamHandler())
-
-log.setLevel(logging.getLevelName(config.get('cthulhu', 'log_level')))
 
 try:
-    try:
-        from salt.client import condition_kwarg  # noqa
-    except ImportError:
-        # Salt moved this in 382dd5e
-        from salt.utils.args import condition_input as condition_kwarg  # noqa
+    from salt.client import condition_kwarg  # noqa
+except ImportError:
+    # Salt moved this in 382dd5e
+    from salt.utils.args import condition_input as condition_kwarg  # noqa
 
-    from salt.client import LocalClient  # noqa
-    from salt.utils.event import MasterEvent  # noqa
-    from salt.key import Key  # noqa
-    from salt.config import master_config  # noqa
-    from salt.utils.master import MasterPillarUtil  # noqa
-    from salt.config import client_config  # noqa
-    try:
-        from salt.loader import _create_loader  # noqa
-    except ImportError:
-        # static_loader added in a422fa42
-        # _create_loader removed in b0e1425
-        from salt.loader import static_loader as _create_loader  # noqa
-except ImportError, e:
-    # log failure everywhere and give up
-    log.exception(e)
-    raise e
+from salt.client import LocalClient  # noqa
+from salt.utils.event import MasterEvent  # noqa
+from salt.key import Key  # noqa
+from salt.config import master_config  # noqa
+from salt.utils.master import MasterPillarUtil  # noqa
+from salt.config import client_config  # noqa
+try:
+    from salt.loader import _create_loader  # noqa
+except ImportError:
+    # static_loader added in a422fa42
+    # _create_loader removed in b0e1425
+    from salt.loader import static_loader as _create_loader  # noqa
 
 
 class SaltEventSource(object):

--- a/conf/supervisord.production.conf
+++ b/conf/supervisord.production.conf
@@ -1,7 +1,13 @@
 
+[supervisord]
+loglevel=warn
+logfile=/var/log/calamari/supervisord.log
+childlogdir=/var/log/calamari
 
 [program:carbon-cache]
 command=/opt/calamari/venv/bin/carbon-cache.py --debug --config /etc/graphite/carbon.conf start
 
 [program:cthulhu]
 command=/opt/calamari/venv/bin/cthulhu-manager
+stderr_logfile = /var/log/calamari/cthulhu_stderr.log
+stdout_logfile = /var/log/calamari/cthulhu_stdout.log


### PR DESCRIPTION
This module gets imported by cthulhu calamari_ctl and rest_api
The permissions on the log files are inherited from the process
previously we just tried to log to all the files which got us in
troublein the case where rest_api(uid: apache) tries to open
cthulhu.log(owner:root)

Fix this at the correct level of abstraction import errors
get sent to stderr use supervisor to catch them on cthulhu
apache should be getting them for rest-api and they all end
up as /var/log/calamari/*.log

Signed-off-by: Gregory Meno <gmeno@redhat.com>