### PR TITLE
RFC: Add LSB build targets, systemd unit file, SUSE spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,22 @@ all: build
 
 build: version build-venv
 
+# Similar to the set in build-venv-reqs, but installs to the global python
+# site dir, not inside a venv.  This allows using distro-supplied dependencies
+# instead of embedding everything
+build-lsb: version
+	for p in \
+		calamari-common \
+		rest-api \
+		calamari-web \
+		cthulhu \
+		calamari-lite \
+	; do \
+		cd $$p ; \
+		python setup.py install --prefix=/usr --root=$(DESTDIR) ; \
+		cd .. ; \
+	done
+
 DATESTR=$(shell /bin/echo -n "built on "; date)
 set_deb_version:
 	@echo "target: $@"
@@ -114,6 +130,11 @@ install-common: install-conf install-venv install-salt install-alembic install-s
 
 install-rpm: build install-common install-rh-conf
 	@echo "target: $@"
+
+install-lsb: build-lsb install-conf
+	@echo "target: $@"
+	$(INSTALL) -D -m 0644 conf/calamari.service \
+		$(DESTDIR)/usr/lib/systemd/system/calamari.service
 
 # for deb
 install: build

--- a/calamari-lite/calamari_lite/server.py
+++ b/calamari-lite/calamari_lite/server.py
@@ -89,10 +89,6 @@ class ShallowCarbonCache(gevent.Greenlet):
 
 
 def main():
-    # Instruct salt to use the gevent version of ZMQ
-    import zmq.green
-    import salt.utils.event
-    salt.utils.event.zmq = zmq.green
 
     carbon = ShallowCarbonCache()
     carbon.start()

--- a/calamari-web/calamari_web/settings.py
+++ b/calamari-web/calamari_web/settings.py
@@ -117,7 +117,8 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'calamari_web.middleware.AngularCSRFRename',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # No authentication ATM
+    #'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/calamari.suse.spec
+++ b/calamari.suse.spec
@@ -1,0 +1,111 @@
+#
+# spec file for package calamari
+#
+# Copyright (c) 2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+Name:           calamari
+Summary:        Manage and monitor Ceph with a REST API
+License:        LGPL-2.1+
+Group:          System/Filesystems
+Version:        1.3+git.1456160171.f7475e3
+Release:        0
+Url:            http://ceph.com/
+Source0:        %{name}-%{version}.tar.gz
+Provides:       calamari-server = %{version}
+Obsoletes:      calamari-server < %{version}
+# Force no database usage
+Conflicts:      python-SQLAlchemy
+Conflicts:      python-alembic
+Requires:       logrotate
+Requires:       python-django < 1.7
+Requires:       python-djangorestframework
+Requires:       python-dateutil
+Requires:       python-zerorpc
+Requires:       python-gevent >= 1.0
+Requires:       python-pytz
+Requires:       python-setuptools
+%{?systemd_requires}
+BuildRequires:  fdupes
+BuildRequires:  python-devel
+BuildRequires:  systemd
+# For lsb_release binary
+BuildRequires:  lsb-release
+BuildRequires:  python-setuptools
+# For /etc/*release files
+%if 0%{?suse_version} == 1315 && (! 0%{?is_opensuse})
+BuildRequires:  sles-release
+%else
+BuildRequires:  suse-release
+%endif
+BuildArch:      noarch
+
+%description
+Calamari is a REST API for monitoring and controlling a Ceph cluster.
+It is intended to be used by other frontent GUIs.
+
+%prep
+%setup -q
+
+%build
+echo "VERSION =\"%{version}\"" > rest-api/calamari_rest/version.py
+
+%install
+make DESTDIR=%{buildroot} install-lsb
+mkdir -p %{buildroot}%{_sbindir}
+ln -s -f %{_sbindir}/service %{buildroot}%{_sbindir}/rccalamari
+%fdupes %{buildroot}%{python_sitelib}
+
+%files
+%defattr(-,root,root,-)
+%doc COPYING*
+%exclude /opt/calamari
+%exclude %{_bindir}/calamari-ctl
+%exclude %{_bindir}/cthulhu-manager
+%exclude %{_sysconfdir}/calamari/alembic.ini
+%exclude %{_sysconfdir}/graphite
+%exclude %{_sysconfdir}/salt
+%exclude %{_sysconfdir}/supervisor
+%{python_sitelib}/calamari_*
+%{python_sitelib}/cthulhu*
+%{_bindir}/calamari-lite
+%{_unitdir}/calamari.service
+%{_sbindir}/rccalamari
+%dir %{_sysconfdir}/calamari
+%config(noreplace) %{_sysconfdir}/calamari/calamari.conf
+%attr (644,-,-) %config(noreplace) %{_sysconfdir}/logrotate.d/calamari
+%dir %{_localstatedir}/log/calamari
+
+%pre
+%service_add_pre calamari.service
+
+%post
+%service_add_post calamari.service
+if [ ! -e /etc/calamari/secret.key ] ; then
+	# This is the same set of characters and whatnot as django's
+	# default secret key generation.
+	cat /dev/urandom | \
+		tr -dc 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(_=+)-' | \
+		head -c 50 > /etc/calamari/secret.key
+	chmod 600 /etc/calamari/secret.key
+fi
+
+%preun
+%service_del_preun calamari.service
+
+%postun
+%service_del_postun calamari.service
+
+%changelog

--- a/calamari.suse.spec
+++ b/calamari.suse.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package calamari
 #
-# Copyright (c) 2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -20,23 +20,23 @@ Name:           calamari
 Summary:        Manage and monitor Ceph with a REST API
 License:        LGPL-2.1+
 Group:          System/Filesystems
-Version:        1.3+git.1456160171.f7475e3
+Version:        1.3+git.1456408184.9f2ca76
 Release:        0
 Url:            http://ceph.com/
 Source0:        %{name}-%{version}.tar.gz
-Provides:       calamari-server = %{version}
-Obsoletes:      calamari-server < %{version}
+# Don't allow installation alongside "big" calamari
+Conflicts:      calamari-server
 # Force no database usage
 Conflicts:      python-SQLAlchemy
 Conflicts:      python-alembic
 Requires:       logrotate
+Requires:       python-dateutil
 Requires:       python-django < 1.7
 Requires:       python-djangorestframework
-Requires:       python-dateutil
-Requires:       python-zerorpc
 Requires:       python-gevent >= 1.0
 Requires:       python-pytz
 Requires:       python-setuptools
+Requires:       python-zerorpc
 %{?systemd_requires}
 BuildRequires:  fdupes
 BuildRequires:  python-devel
@@ -55,6 +55,10 @@ BuildArch:      noarch
 %description
 Calamari is a REST API for monitoring and controlling a Ceph cluster.
 It is intended to be used by other frontent GUIs.
+
+This calamari package is to be installed and run directly on Ceph MONs,
+as opposed to previous versions which were packaged as calamari-server
+and run on a separate host, using salt to talk to the cluster.
 
 %prep
 %setup -q

--- a/calamari.suse.spec
+++ b/calamari.suse.spec
@@ -31,7 +31,7 @@ Conflicts:      python-SQLAlchemy
 Conflicts:      python-alembic
 Requires:       logrotate
 Requires:       python-dateutil
-Requires:       python-django < 1.7
+Requires:       python-django
 Requires:       python-djangorestframework
 Requires:       python-gevent >= 1.0
 Requires:       python-pytz

--- a/conf/calamari.service
+++ b/conf/calamari.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Calamari REST API
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/calamari-lite
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/calamari/suse/calamari.conf
+++ b/conf/calamari/suse/calamari.conf
@@ -28,7 +28,7 @@ db_user = calamari
 db_password = 27HbZwr*g
 db_host = localhost
 db_port = 5432
-secret_key_path = /srv/www/calamari/secret.key
+secret_key_path = /etc/calamari/secret.key
 username = wwwrun
 static_root = /srv/www/calamari/content/
 


### PR DESCRIPTION
This is about the minimum amount necessary to create an RPM package for Calamari-on-MON which uses distro packaged dependencies (python-django etc.) rather than packing everything into a virtualenv. It also adds a systemd unit file for calamari lite, so we don't need supervisord. I've done the spec file as a SUSE-specific variant to make it easy to see what it looks like, rather than editing the existing calamari.spec. Comments appreciated ;-)