### PR TITLE
ceph-module: handle fsmap epoch to support Jewel

### DIFF
--- a/salt/srv/salt/_modules/ceph.py
+++ b/salt/srv/salt/_modules/ceph.py
@@ -622,9 +622,9 @@ def cluster_status(cluster_handle, cluster_name):
     status = rados_command(cluster_handle, "status")
 
     fsid = status['fsid']
-    mon_epoch = status['monmap']['epoch']
-    osd_epoch = status['osdmap']['osdmap']['epoch']
-    mds_epoch = status['mdsmap']['epoch']
+    mon_epoch = status.get('monmap', {}).get('epoch')
+    osd_epoch = status.get('osdmap', {}).get('osdmap', {}).get('epoch')
+    mds_epoch = status.get('fsmap', status.get('mdsmap', {})).get('epoch')
 
     # FIXME: even on a healthy system, 'health detail' contains some statistics
     # that change on their own, such as 'last_updated' and the mon space usage.


### PR DESCRIPTION
This is derived from commit 5c331c2 on the 1.4 branch (except that's on
mon_remote.py), but will try to get the fsmap epoch if present instead
of the mdsmap epoch.

Rationale: The Jewel release `ceph status` JSON blob includes an
"fsmap" dict, apparently instead of the old "mdsmap" dict.  This means
that the current implementation of the salt module will fail with
"KeyError: 'mdsmap'" when run against Jewel.  AFAICT this exception
isn't actually reported anywhere, it just silently fails and Calamari
thinks there's no cluster configured.

Signed-off-by: Tim Serong <tserong@suse.com>