### PR TITLE
debian/control: try installing virtualenv first, if it exists

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: debhelper (>= 9),
                lsb-release,
                python-dev,
                python-pip,
-               python-virtualenv
+               virtualenv | python-virtualenv
 
 Package: calamari-server
 Architecture: any


### PR DESCRIPTION
On Ubuntu Xenial, the package is "virtualenv".