### PR TITLE
drop carbon setup.py hack and use carbon 0.9.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,26 +68,9 @@ $(VERSION_PY):
 	echo "VERSION = \"$(VERSION)-$(REVISION)$(BPTAG)\"" > $(VERSION_PY)
 
 # separate targets exist below for debugging; the expected order is
-# "venv -> build-venv-carbon/build-venv-reqs -> fixup-venv"
+# "venv -> build-venv-reqs -> fixup-venv"
 
 build-venv: fixup-venv
-
-# try for idempotency with pip freeze | grep carbon
-build-venv-carbon: venv
-	@echo "target: $@"
-	set -ex; \
-	(export PYTHONDONTWRITEBYTECODE=1; \
-	cd venv; \
-	pyver=$$(./bin/python -c 'import sys; print "{0}.{1}".format(sys.version_info[0], sys.version_info[1])') ; \
-	if ! ./bin/python ./bin/pip freeze | grep -s -q carbon ; then \
-		./bin/python ./bin/pip install --no-install carbon; \
-		sed -i 's/== .redhat./== "DONTDOTHISredhat"/' \
-			build/carbon/setup.py; \
-		./bin/python ./bin/pip install --no-download \
-		  --install-option="--prefix=$(SRC)/venv" \
-		  --install-option="--install-lib=$(SRC)/venv/lib/python$${pyver}/site-packages" carbon; \
-	fi \
-	)
 
 build-venv-reqs: venv
 	@echo "target: $@"
@@ -109,7 +92,7 @@ build-venv-reqs: venv
 	../venv/bin/python ./setup.py install && \
 	cd ../venv ; )
 
-fixup-venv: build-venv-carbon build-venv-reqs
+fixup-venv: build-venv-reqs
 	@echo "target: $@"
 	set -x; \
 	cd venv; \

--- a/requirements/2.7/requirements.production.txt
+++ b/requirements/2.7/requirements.production.txt
@@ -6,6 +6,7 @@
 
 Django==1.5.1
 argparse==1.2.1
+carbon==0.9.15
 django-filter==0.6
 djangorestframework==2.3.12
 wsgiref==0.1.2


### PR DESCRIPTION
Prior to Carbon 0.9.11, Carbon's `setup.py` script would install files to `/etc/init.d`. To avoid this behavior, Calamari's `Makefile` used `sed` to rewrite `setup.py` and stop doing that.

Newer versions of Carbon have dropped this mis-feature, so we can now rely on the stock version from PyPI without the hack.

Drop the custom `Makefile` bits that rewrote carbon's `setup.py` script. Add carbon to the production requirements.txt. (0.9.15 is the latest upstream version at the time of this commit.)

Thanks @dmick for helping with investigating this issue.

This change has the side effect of giving us compatibility with Ubuntu Xenial's pip v8.1.1. Pip 8 has no longer supports the `--no-install` and `--no-download` arguments to `pip install`.