### PR TITLE
remove salt depends in calamari-server on ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,8 +23,6 @@ Depends: apache2,
          logrotate,
          postgresql,
          python-cairo,
-         salt-master,
-         salt-minion,
          supervisor,
          ${misc:Depends},
          ${python:Depends}


### PR DESCRIPTION
Signed-off-by: Gregory Meno <gmeno@redhat.com>