### PR TITLE
simplify carbon install, take 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,9 @@ build-venv-carbon: venv
 	cd venv; \
 	pyver=$$(./bin/python -c 'import sys; print "{0}.{1}".format(sys.version_info[0], sys.version_info[1])') ; \
 	if ! ./bin/python ./bin/pip freeze | grep -s -q carbon ; then \
-		./bin/python ./bin/pip install --no-install carbon; \
-		sed -i 's/== .redhat./== "DONTDOTHISredhat"/' \
-			build/carbon/setup.py; \
-		./bin/python ./bin/pip install --no-download \
+		./bin/python ./bin/pip install \
 		  --install-option="--prefix=$(SRC)/venv" \
-		  --install-option="--install-lib=$(SRC)/venv/lib/python$${pyver}/site-packages" carbon; \
+		  --install-option="--install-lib=$(SRC)/venv/lib/python$${pyver}/site-packages" carbon==0.9.15; \
 	fi \
 	)
 

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,26 @@ $(VERSION_PY):
 	echo "VERSION = \"$(VERSION)-$(REVISION)$(BPTAG)\"" > $(VERSION_PY)
 
 # separate targets exist below for debugging; the expected order is
-# "venv -> build-venv-reqs -> fixup-venv"
+# "venv -> build-venv-carbon/build-venv-reqs -> fixup-venv"
 
 build-venv: fixup-venv
+
+# try for idempotency with pip freeze | grep carbon
+build-venv-carbon: venv
+	@echo "target: $@"
+	set -ex; \
+	(export PYTHONDONTWRITEBYTECODE=1; \
+	cd venv; \
+	pyver=$$(./bin/python -c 'import sys; print "{0}.{1}".format(sys.version_info[0], sys.version_info[1])') ; \
+	if ! ./bin/python ./bin/pip freeze | grep -s -q carbon ; then \
+		./bin/python ./bin/pip install --no-install carbon; \
+		sed -i 's/== .redhat./== "DONTDOTHISredhat"/' \
+			build/carbon/setup.py; \
+		./bin/python ./bin/pip install --no-download \
+		  --install-option="--prefix=$(SRC)/venv" \
+		  --install-option="--install-lib=$(SRC)/venv/lib/python$${pyver}/site-packages" carbon; \
+	fi \
+	)
 
 build-venv-reqs: venv
 	@echo "target: $@"
@@ -92,7 +109,7 @@ build-venv-reqs: venv
 	../venv/bin/python ./setup.py install && \
 	cd ../venv ; )
 
-fixup-venv: build-venv-reqs
+fixup-venv: build-venv-carbon build-venv-reqs
 	@echo "target: $@"
 	set -x; \
 	cd venv; \

--- a/requirements/2.7/requirements.production.txt
+++ b/requirements/2.7/requirements.production.txt
@@ -6,7 +6,6 @@
 
 Django==1.5.1
 argparse==1.2.1
-carbon==0.9.15
 django-filter==0.6
 djangorestframework==2.3.12
 wsgiref==0.1.2


### PR DESCRIPTION
My previous patch (https://github.com/ceph/calamari/commit/55fb7c683ca29d87b9f337960d8f9bac8bb481c4) went too far in simplifying the carbon installation, because carbon 0.9.x still tries to write to `/opt/graphite`.

Re-do the change, keeping the `build-venv-carbon` make target, and just removing the `--no-install` + `sed` + `--no-download` bits.