### PR TITLE
only run initdb when pg_hba.conf hasn't been created. Fixes rhbz 1333210

### DIFF
--- a/salt/local/postgres.sls
+++ b/salt/local/postgres.sls
@@ -9,11 +9,13 @@ postgresql_initdb:
     cmd:
         - run
         - name: postgresql-setup initdb
+        - creates: /var/lib/pgsql/data/pg_hba.conf
 {% else %}
 postgresql_initdb:
     cmd:
         - run
         - name: postgresql-setup --initdb
+        - creates: /var/lib/pgsql/data/pg_hba.conf
 {% endif %}
 
 # change 'host' auth to 'md5' for local hashed-password authorization
@@ -58,6 +60,7 @@ postgresql_initdb:
     cmd:
         - run
         - name: service postgresql initdb
+        - creates: /var/lib/pgsql/data/pg_hba.conf
 
 # change 'host' auth to 'md5' for local hashed-password authorization
 /var/lib/pgsql/data/pg_hba.conf:


### PR DESCRIPTION
`initdb` creates contents in `data/*` including a `pg_hba.conf`. When installing postgresql this directory is empty.

On an upgrade situation, that directory wouldn't be empty and the command would fail.

RH BZ issue: https://bugzilla.redhat.com/show_bug.cgi?id=1333210