### PR TITLE
calamari: ignore ENOENT in calamari-crush-location

### DIFF
--- a/salt/srv/salt/base/calamari-crush-location.py
+++ b/salt/srv/salt/base/calamari-crush-location.py
@@ -28,9 +28,10 @@ def get_last_crush_location(cluster, osd_id):
         proc = Popen(c, stdout=PIPE, stderr=PIPE)
         out, err = proc.communicate()
         if proc.returncode != 0:
-            errors.append("Error {0} running {1}:'{2}'".format(
-                proc.returncode, 'ceph config-key get', err.strip()
-            ))
+            if "ENOENT" not in err:     # ENOENT means key doesn't exist, which is fine.
+                errors.append("Error {0} running {1}:'{2}'".format(
+                    proc.returncode, 'ceph config-key get', err.strip()
+                ))
         else:
             return json.loads(out.strip())
 


### PR DESCRIPTION
If the last CRUSH location isn't set for an OSD (which apparently it
usually won't be), calamari-crush-location prints out error messages
which eventually appear in `systemctl status ceph-osd@$N` output:

ERROR:calamari_osd_location:Error 2 running ceph config-key get:'Error
ENOENT: error obtaining
'daemon-private/osd.2/v1/calamari/osd_crush_location': (2) No such file
or directory'

This makes it look like something is broken, when everything is actually
fine, so this commit suppresses ENOENT errors.

Signed-off-by: Tim Serong <tserong@suse.com>