### PR TITLE
get hostnames for server endpoint from osd_metadata

### DIFF
--- a/cthulhu/cthulhu/manager/server_monitor.py
+++ b/cthulhu/cthulhu/manager/server_monitor.py
@@ -186,18 +186,12 @@ class ServerMonitor(greenlet.Greenlet):
                     found.extend(find_descendants(nodes_by_id[child_id], fn))
                 return found
 
-        # This assumes that:
-        # - The host and OSD types exist and have the names set
-        #   in CRUSH_HOST_TYPE and CRUSH_OSD_TYPE
-        # - That OSDs are descendents of hosts
-        # - That hosts have the 'name' attribute set to their hostname
-        # - That OSDs have the 'name' attribute set to osd.<osd id>
-        # - That OSDs are not descendents of OSDs
-        for node in osd_tree["nodes"]:
-            if node["type"] == CRUSH_HOST_TYPE:
-                host = node["name"]
-                for osd in find_descendants(node, lambda c: c['type'] == CRUSH_OSD_TYPE):
-                    osd_id_to_host[osd["id"]] = host
+        osd_metadata = osd_map.get('osd_metadata', [])
+        if not osd_metadata:
+            log.error("get_hostname_to_osds unable to get osd_metadata")
+
+        for osd in osd_metadata:
+                osd_id_to_host[osd['id']] = osd['hostname']
 
         for osd in osd_map['osds']:
             try:


### PR DESCRIPTION
We no longer have to infer the names of OSD hosts
from the crushmap.

Signed-off-by: Gregory Meno <gmeno@redhat.com>