### PR TITLE
fix calamari-ctl initialize

### DIFF
--- a/conf/calamari/debian/calamari.conf
+++ b/conf/calamari/debian/calamari.conf
@@ -29,7 +29,7 @@ db_password = 27HbZwr*g
 db_host = localhost
 db_port = 5432
 secret_key_path = /opt/calamari/webapp/secret.key
-username = www-data
+username = root
 static_root = /opt/calamari/webapp/content/
 
 [graphite]

--- a/conf/calamari/el6/calamari.conf
+++ b/conf/calamari/el6/calamari.conf
@@ -29,7 +29,7 @@ db_password = 27HbZwr*g
 db_host = localhost
 db_port = 5432
 secret_key_path = /opt/calamari/webapp/secret.key
-username = apache
+username = root
 static_root = /opt/calamari/webapp/content/
 
 [graphite]

--- a/conf/calamari/rhel7/calamari.conf
+++ b/conf/calamari/rhel7/calamari.conf
@@ -29,7 +29,7 @@ db_password = 27HbZwr*g
 db_host = localhost
 db_port = 5432
 secret_key_path = /opt/calamari/webapp/secret.key
-username = apache
+username = root
 static_root = /opt/calamari/webapp/content/
 
 [graphite]

--- a/conf/calamari/suse/calamari.conf
+++ b/conf/calamari/suse/calamari.conf
@@ -29,7 +29,7 @@ db_password = 27HbZwr*g
 db_host = localhost
 db_port = 5432
 secret_key_path = /etc/calamari/secret.key
-username = wwwrun
+username = root
 static_root = /srv/www/calamari/content/
 
 [graphite]


### PR DESCRIPTION
There is code that tries to chown some paths
to be RW by apache, since we're no longer
using apache to server and aren't depending on
the httpd package there is not user to
successfully chown this stuff to
calamari-lite runs as root leave them root

Signed-off-by: Gregory Meno <gmeno@redhat.com>