### PR TITLE
change 'mdsmap' to 'fsmap' for ceph version from jewel

### DIFF
--- a/salt/srv/salt/_modules/ceph.py
+++ b/salt/srv/salt/_modules/ceph.py
@@ -624,7 +624,16 @@ def cluster_status(cluster_handle, cluster_name):
     fsid = status['fsid']
     mon_epoch = status['monmap']['epoch']
     osd_epoch = status['osdmap']['osdmap']['epoch']
-    mds_epoch = status['mdsmap']['epoch']
+
+    # for ceph version begin from jewel, the 'mdsmap' has been changed to 'fsmap'.
+    ceph_version_str = __salt__['pkg.version']('ceph')  # noqa
+    if ceph_version_str:
+        ceph_version_list = ceph_version_str.split('.')
+
+    if ceph_version_list and int(ceph_version_list[0]) >= 10:
+        mds_epoch = status['fsmap']['epoch']
+    else:
+        mds_epoch = status['mdsmap']['epoch']
 
     # FIXME: even on a healthy system, 'health detail' contains some statistics
     # that change on their own, such as 'last_updated' and the mon space usage.


### PR DESCRIPTION
File "/usr/local/lib/python2.7/dist-packages/salt/minion.py", line 1019, in _thread_return
    return_data = func(*args, **kwargs)
  File "/var/cache/salt/minion/extmods/modules/ceph.py", line 498, in get_heartbeats
    cluster_heartbeat[fsid] = cluster_status(cluster_handle, fsid_names[fsid])
  File "/var/cache/salt/minion/extmods/modules/ceph.py", line 566, in cluster_status
    mds_epoch = status['mdsmap']['epoch']
KeyError: 'mdsmap'
