### PR TITLE
vagrant/trusty-build: force reset the git repos

### DIFF
--- a/vagrant/trusty-build/salt/roots/git_clone.sls
+++ b/vagrant/trusty-build/salt/roots/git_clone.sls
@@ -6,6 +6,7 @@ calamari_clone:
     - user: {{vars.username}}
     - target: {{vars.builddir}}/calamari
     - name: {{vars.gitpath}}/calamari
+    - force_reset: True
     - require:
       - pkg: build_deps
 
@@ -15,5 +16,6 @@ diamond_clone:
     - user: {{vars.username}}
     - target: {{vars.builddir}}/Diamond
     - name: {{vars.gitpath}}/Diamond
+    - force_reset: True
     - require:
       - pkg: build_deps


### PR DESCRIPTION
We fail if the current repo is newer than what is currently in the git repos. This will allow salt to update the refs.