### PR TITLE
rpm: Make spec file a template

### DIFF
--- a/calamari-server.spec.in
+++ b/calamari-server.spec.in
@@ -49,8 +49,8 @@ Requires:       policycoreutils, libselinux-utils
 Requires(post): selinux-policy >= %{_selinux_policy_version}, policycoreutils
 Requires(postun): policycoreutils
 %endif
-Version: 	%{version}
-Release: 	%{?revision}%{?dist}
+Version: 	@VERSION@
+Release: 	@RELEASE@%{?dist}
 License: 	LGPL-2.1+
 URL:     	http://ceph.com/
 Source0: 	%{name}_%{version}.tar.gz


### PR DESCRIPTION
Signed-off-by: Boris Ranto <branto@redhat.com>

We can later use jenkins to generate a regular spec file from the template as in

https://github.com/ceph/ceph-build/blob/master/calamari-setup/build/build#L43