### PR TITLE
diamond: start the service with the initscript

### DIFF
--- a/salt/srv/salt/diamond.sls
+++ b/salt/srv/salt/diamond.sls
@@ -43,7 +43,7 @@ diamond:
     - skip_verify: true
   cmd:
     - run
-    - name: systemctl restart diamond
+    - name: /etc/init.d/diamond restart
     - watch:
       - pkg: diamond
       - file: diamond-network-config


### PR DESCRIPTION
the version of diamond that we currently lacks
systemd control files. I've rebased our work on
diamond-4.0 which will fix this correctly so that
we can use systemd to start it. This initscript
workaround is here till that package gets tested
and accepted upstream.

Signed-off-by: Gregory Meno <gmeno@redhat.com>