### PR TITLE
Pass /dev/null as stdin when calling ceph commands

### DIFF
--- a/salt/srv/salt/_modules/ceph.py
+++ b/salt/srv/salt/_modules/ceph.py
@@ -306,7 +306,7 @@ def ceph_command(cluster_name, command_args):
     else:
         args = ["ceph"] + command_args
 
-    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=open(os.devnull, "r"))
     stdout, stderr = p.communicate()
     status = p.returncode
 
@@ -332,7 +332,7 @@ def rbd_command(command_args, pool_name=None):
     else:
         args = ["rbd"] + command_args
 
-    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=open(os.devnull, "r"))
     stdout, stderr = p.communicate()
     status = p.returncode
 
@@ -354,7 +354,7 @@ def radosgw_admin_command(command_args):
 
     args = ["radosgw-admin"] + command_args
 
-    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=open(os.devnull, "r"))
     stdout, stderr = p.communicate()
     status = p.returncode
 


### PR DESCRIPTION
Currently, we run these commands with default stdin which resolves to
tty from which the daemon is run. For commands like 'rbd watch <img>'
which wait for an input, this can result in commands being hung forever.

The patch fixes this by attaching the stdin to /dev/null so the commands
like that will get EOF on stdin and exit immediately.

Signed-off-by: Boris Ranto branto@redhat.com
