### PR TITLE
Updated the module name to match the package name

### DIFF
--- a/selinux/calamari-server.te
+++ b/selinux/calamari-server.te
@@ -1,5 +1,5 @@
 
-module calamari 1.0;
+module calamari-server 1.0;
 
 require {
 	type var_log_t;


### PR DESCRIPTION
Will not build on fedora 24 because module name does not match package name

/usr/bin/checkmodule:  Module name calamari is different than the output base filename calamari-server