### PR TITLE
Add /cluster/<fsid>/{pool/<id>/}stats endpoints

### DIFF
--- a/rest-api/calamari_rest/serializers/v2.py
+++ b/rest-api/calamari_rest/serializers/v2.py
@@ -426,3 +426,32 @@ class CliSerializer(serializers.Serializer):
     out = serializers.CharField(help_text="Standard out")
     err = serializers.CharField(help_text="Standard error")
     status = serializers.IntegerField(help_text="Exit code")
+
+
+class ClusterStatsSerializer(serializers.Serializer):
+    class Meta:
+        fields = ('kb', 'num_objects', 'kb_avail', 'kb_used')
+
+    kb = serializers.IntegerField(help_text='total kb')
+    num_objects = serializers.IntegerField(help_text='total number of objects')
+    kb_avail = serializers.IntegerField(help_text='available kb')
+    kb_used = serializers.IntegerField(help_text='used kb')
+
+
+class PoolStatsSerializer(serializers.Serializer):
+    class Meta:
+        fields = ('name', 'num_objects_unfound', 'num_objects_missing_on_primary', 'num_object_clones', 'num_objects', 'num_object_copies', 'num_bytes', 'num_rd_kb', 'num_wr_kb', 'num_kb', 'num_wr', 'num_objects_degraded', 'num_rd')
+
+    name = serializers.CharField()
+    num_objects_unfound = serializers.IntegerField()
+    num_objects_missing_on_primary = serializers.IntegerField()
+    num_object_clones = serializers.IntegerField()
+    num_objects = serializers.IntegerField()
+    num_object_copies = serializers.IntegerField()
+    num_bytes = serializers.IntegerField()
+    num_rd_kb = serializers.IntegerField()
+    num_wr_kb = serializers.IntegerField()
+    num_kb = serializers.IntegerField()
+    num_wr = serializers.IntegerField()
+    num_objects_degraded = serializers.IntegerField()
+    num_rd = serializers.IntegerField()

--- a/rest-api/calamari_rest/urls/v2.py
+++ b/rest-api/calamari_rest/urls/v2.py
@@ -42,7 +42,7 @@ urlpatterns = patterns(
         calamari_rest.views.v2.RequestViewSet.as_view({'get': 'list'}),
         name='cluster-request-list'),
 
-    # OSDs, Pools, CRUSH
+    # OSDs, Pools, CRUSH, stats
     url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/crush_map$',
         calamari_rest.views.v2.CrushMapViewSet.as_view({'get': 'retrieve', 'post': 'replace'}),
         name='cluster-crush_map'),
@@ -75,6 +75,14 @@ urlpatterns = patterns(
                                                     'patch': 'update',
                                                     'delete': 'destroy'}),
         name='cluster-pool-detail'),
+    url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/pool/(?P<pool_id>\d+)/stats$',
+        calamari_rest.views.v2.PoolStatsViewSet.as_view({'get': 'retrieve'}),
+        name='cluster-pool-stats'),
+    url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/pool/stats$',
+        calamari_rest.views.v2.PoolStatsViewSet.as_view({'get': 'list'}),
+        name='cluster-pools-stats'),
+    url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/stats$',
+        calamari_rest.views.v2.ClusterStatsViewSet.as_view({'get': 'retrieve'})),
 
     url(r'^cluster/(?P<fsid>[a-zA-Z0-9-]+)/osd$',
         calamari_rest.views.v2.OsdViewSet.as_view({'get': 'list'}),


### PR DESCRIPTION
The commit adds two stats endpoints that provide global cluster as well
per pool statistics.

Signed-off-by: Boris Ranto <branto@redhat.com>