### PR TITLE
mon_remote: Do not match dot in service type

### DIFF
--- a/calamari-common/calamari_common/remote/mon_remote.py
+++ b/calamari-common/calamari_common/remote/mon_remote.py
@@ -591,7 +591,7 @@ def service_status(socket_path):
     """
     Given an admin socket path, learn all we can about that service
     """
-    match = re.match("^(.*)-(.*)\.(.*).asok$", os.path.basename(socket_path))
+    match = re.match("^(.*)-([^\.]*)\.(.*).asok$", os.path.basename(socket_path))
     if match:
         cluster_name, service_type, service_id = match.groups()
     else:


### PR DESCRIPTION
Currently, we match the asok file all the way to the last dot for the
service type. This fails if we use FQDNs since it matches all the way to
.com. The patch fixes this so that we do not match dot for service type.

Signed-off-by: Boris Ranto <branto@redhat.com>