### PR TITLE
bump gevent to 1.1.1 for Calamari 1.5

### DIFF
--- a/requirements/2.7/requirements.production.txt
+++ b/requirements/2.7/requirements.production.txt
@@ -13,7 +13,7 @@ sqlalchemy==0.8.3
 alembic==0.6.3
 setuptools
 cython
-gevent==1.1.0
+gevent==1.1.1
 greenlet
 manhole==0.6.0
 


### PR DESCRIPTION
In the Calamari 1.4 series, we had `gevent>=1.1` in `requirements.txt`.

Commit 14bf202abdeb9c4b0d2cabe365f483eb4eb7a054 altered the gevent version slightly to pin to an exact gevent version (v1.1.0).

This means we went slightly backwards from Calamari v1.4.z, because `>=1.1` would cause Pip to pull in gevent v1.1.1, whereas now we pin to v1.1.0.

After discussing with gmeno, let's continue using gevent 1.1.1 here.