### PR TITLE
lite.txt: bump gevent to 1.1.1

### DIFF
--- a/requirements/lite.txt
+++ b/requirements/lite.txt
@@ -12,7 +12,7 @@ meld3
 # Gevent 1.0.x requires cython but doesn't do a good job of depending on it
 setuptools
 cython
-gevent==1.1.0
+gevent==1.1.1
 greenlet>=0.3.2
 
 # Cthulhu


### PR DESCRIPTION
In commit 7075d889f50bc3e33ae5f680a0aad605dc8e4917, I bumped gevent to 1.1.1. Bump lite.txt as well to match this.