### PR TITLE
debian: stop using dh_python2 ${python:Depends}

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,8 +22,12 @@ Depends: libcairo2,
          openssl,
          python-cairo,
          sqlite3,
-         ${misc:Depends},
-         ${python:Depends}
+         python:any,
+         python-twisted,
+         python-txamqp,
+         python-pkg-resources,
+         python-six,
+         ${misc:Depends}
 Description: Inktank package containing the Calamari management server
  Calamari is a webapp to monitor and control a Ceph cluster via a web
  browser.


### PR DESCRIPTION
When dh_python2 parses the `requires.txt` files in Calamari and Calamari's bundled libraries, it translates the dependencies listed there into "python-" packages and adds them into `${python:Depends}`.

In the past this has led to the calamari-server .deb depending on system packages that do not exist, which leads to installation failures.

Since `${python:Depends}` doesn't work well with Calamari's method of bundling libraries in a virtualenv, just remove it and hard-code the list of python Depends in /debian/control.

(I've just copied & pasted the existing list that dh_python2 was already picking up, so maybe this Depends list could be trimmed further, with experimentation.)