### PR TITLE
Fix build-rpm.sh spec

### DIFF
--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -13,18 +13,20 @@ TARNAME="calamari-server_*tar.gz"
 # Set up build area
 mkdir -p ${RPMBUILD}/{SOURCES,SRPMS,SPECS,RPMS,BUILD}
 cp -a ${TARNAME} ${RPMBUILD}/SOURCES
-cp -a calamari/calamari.spec ${RPMBUILD}/SPECS
+cp -a calamari/calamari-server.spec.in ${RPMBUILD}/SPECS
 
 # set VERSION and REVISION so make doesn't try to get it from git
 # (as it'll be off in the BUILD/ dir, which isn't a git repo)
 
 eval $(cd ${SRC}; ./get-versions.sh -r)
+RPM_RELEASE=$(echo $REVISION | tr '-' '_')
 export VERSION
 export REVISION
+sed -e "s/@VERSION@/${VERSION}/g" -e "s/@RELEASE@/${RPM_RELEASE}/g" < ${RPMBUILD}/SPECS/calamari-server.spec.in > ${RPMBUILD}/SPECS/calamari-server.spec
 
 # Build RPMs
 cd ${RPMBUILD}
-rpmbuild -bb --define "_topdir ${RPMBUILD}" --define "_unpackaged_files_terminate_build 0" --define "version ${VERSION}" --define "revision ${REVISION}" SPECS/calamari.spec
+rpmbuild -bb --define "_topdir ${RPMBUILD}" --define "_unpackaged_files_terminate_build 0" --define "version ${VERSION}" --define "revision ${REVISION}" SPECS/calamari-server.spec
 
 # XXX who signs when?
 


### PR DESCRIPTION
Adapted from [here](https://github.com/ceph/ceph-build/blob/master/calamari/build/build_rpm).