### PR TITLE
packaging: drop "apache" uid/gid ownership on directories

### DIFF
--- a/calamari-server.spec.in
+++ b/calamari-server.spec.in
@@ -82,19 +82,19 @@ browser.
 /opt/calamari/alembic
 /opt/calamari/conf
 /opt/calamari/venv
-%attr (-, apache, apache) /opt/calamari/webapp/calamari
+/opt/calamari/webapp/calamari
 %{_sysconfdir}/graphite/
 %{_sysconfdir}/logrotate.d/calamari
 %{_sysconfdir}/calamari/
 /usr/bin/calamari-ctl
 %dir /var/lib/calamari
 %dir /var/lib/cthulhu
-%dir %attr (755, apache, apache) /var/log/calamari
-%dir %attr (755, apache, apache) /var/log/graphite
-%dir %attr(-, apache, apache) /var/lib/graphite
-%dir %attr(-, apache, apache) /var/lib/graphite/log
-%dir %attr(-, apache, apache) /var/lib/graphite/log/webapp
-%dir %attr(-, apache, apache) /var/lib/graphite/whisper
+%dir %attr (755, root, root) /var/log/calamari
+%dir %attr (755, root, root) /var/log/graphite
+%dir /var/lib/graphite
+%dir /var/lib/graphite/log
+%dir /var/lib/graphite/log/webapp
+%dir /var/lib/graphite/whisper
 %if 0%{?fedora} || 0%{?rhel}
 %doc selinux/*
 %{_datadir}/selinux/*/calamari-server.pp

--- a/debian/calamari-server.postinst
+++ b/debian/calamari-server.postinst
@@ -1,32 +1,13 @@
 #!/bin/bash
 
-calamari_httpd()
-{
-    d=$(pwd)
-    # allow apache access to all
-    chown -R www-data:www-data /opt/calamari/webapp/calamari
-
-    # www-data shouldn't need to write, but it does because graphite creates index on read
-    chown -R www-data:www-data /var/lib/graphite
-
-    chown -R www-data:www-data /var/log/calamari
-    cd $d
-
-}
-
 case "$1" in
     configure)
-        calamari_httpd
-
         # Prompt the user to proceed with the final script-driven
         # part of the installation process
         echo "Thank you for installing Calamari."
         echo ""
         echo "Please run 'sudo calamari-ctl initialize' to complete the installation."
 
-        # rpm/centos
-        # service httpd restart
-        # chkconfig httpd on
         ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Now that we run as root and serve HTTPS without Apache, we don't need to chown directories to the apache user. In fact, since the RPM and Deb doesn't depend on the Apache packages any more, this UID may not even exist on the system.

For RPMs, this could lead to UID/GID warnings in `rpm --verify calamari-server`, since the rpmdb thinks directories should be owned by "apache", but they end up owned by "root" when the httpd RPM is not installed.